### PR TITLE
Add support for multiple contract methods with same name

### DIFF
--- a/Sources/Core/Contract/ContractProtocol.swift
+++ b/Sources/Core/Contract/ContractProtocol.swift
@@ -263,7 +263,7 @@ extension DefaultContractProtocol {
         let method = Data.fromHex(method) == nil ? method : method.addHexPrefix().lowercased()
 
         // MARK: - Encoding ABI Data flow
-        guard let abiMethod = methods[method]?.first,
+        guard let abiMethod = methods[method]?.first(where: { $0.inputs.count == parameters.count }),
               var encodedData = abiMethod.encodeParameters(parameters) else { return nil }
 
         // Extra data just appends in the end of parameters data


### PR DESCRIPTION
Motivation: given ABI with multiple methods with same name and different input count [[example](https://github.com/JoinColony/colonyJS/blob/main/src/abis/flwss/IColonyNetwork.json#L1151-L1158)], add ability to select correct method. 

Implementation: instead of just `first` method - select by number of input parameters. 