### PR TITLE
fix!: web3 error output fix

### DIFF
--- a/Sources/Core/Web3Error/Web3Error.swift
+++ b/Sources/Core/Web3Error/Web3Error.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum Web3Error: Error {
+public enum Web3Error: LocalizedError {
     case transactionSerializationError
     case connectionError
 
@@ -25,7 +25,7 @@ public enum Web3Error: Error {
     case generalError(err: Error)
     case unknownError
 
-    public var errorDescription: String {
+    public var errorDescription: String? {
         switch self {
 
         case .transactionSerializationError:

--- a/Tests/web3swiftTests/localTests/Web3ErrorTests.swift
+++ b/Tests/web3swiftTests/localTests/Web3ErrorTests.swift
@@ -1,0 +1,25 @@
+//
+//  Web3ErrorTests.swift
+//
+//  Created by JeneaVranceanu on 11.11.2022.
+//
+
+import XCTest
+import Foundation
+@testable import Core
+
+class Web3ErrorTests: XCTestCase {
+
+    func test_web3ErrorReturnsExpectedDescription() {
+        let emojis = ["🚀", "👋", "🥇", "☑️"]
+        let message = "This is a custom description for test case! web3swift \(emojis.randomElement()!)"
+
+        /// It's important that we represent `Web3Error` as a generic `Error`!
+        /// This is intentional as in `do-catch` block we do not receive `Web3Error`
+        /// but `Error` type instead that can be casted.
+        let error: Error = Web3Error.inputError(desc: message)
+        XCTAssertEqual(error.localizedDescription, message)
+    }
+
+}
+

--- a/Tests/web3swiftTests/localTests/Web3ErrorTests.swift
+++ b/Tests/web3swiftTests/localTests/Web3ErrorTests.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class Web3ErrorTests: XCTestCase {
 
-    func test_web3ErrorReturnsExpectedDescription() {
+    func testWeb3ErrorReturnsExpectedDescription() {
         let emojis = ["🚀", "👋", "🥇", "☑️"]
         let message = "This is a custom description for test case! web3swift \(emojis.randomElement()!)"
 


### PR DESCRIPTION
PR contains breaking change! Changed type of `errorDescription: String` to `errorDescription: String?`.
This change is easy to "fix" but still it's breaking.

Improved output of the error when calling `error.localizedDescription` and the error is of type `Web3Error`.

Before (useless output):
```
2022-11-11 17:56:25.037294+0200 xctest[49120:505590] The operation couldn’t be completed. (Core.Web3Error error 3.)
```

After (copied log from a test case):
```
2022-11-11 17:56:58.722827+0200 xctest[49218:507026] This is a custom description for the test case! web3swift 🥇
```
