### PR TITLE
Fix validation in SPI package list

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,14 +3,6 @@
 
 import PackageDescription
 
-#if os(macOS)
-let excludeFiles = [
-    "./Browser/BrowserViewController.swift" // Because of inheriting iOS only class failed to build on macOS.
-]
-#else
-let excludeFiles: [String] = []
-#endif
-
 let package = Package(
     name: "Web3swift",
     platforms: [
@@ -32,7 +24,6 @@ let package = Package(
         .target(
             name: "web3swift",
             dependencies: ["Core", "BigInt", "secp256k1"],
-            exclude: excludeFiles,
             resources: [
                 .copy("./Browser/browser.js"),
                 .copy("./Browser/browser.min.js"),

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let excludeFiles = [
     "./Browser/BrowserViewController.swift" // Because of inheriting iOS only class failed to build on macOS.
 ]
 #else
-let excludeFiles: String = []
+let excludeFiles: [String] = []
 #endif
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ import PackageDescription
 let excludeFiles = [
     "./Browser/BrowserViewController.swift" // Because of inheriting iOS only class failed to build on macOS.
 ]
-#elseif os(iOS)
+#else
 let excludeFiles: String = []
 #endif
 


### PR DESCRIPTION
The [Swift Package Index](https://swiftpackageindex.com) package list validation runs on Linux, which [prevents this package from being added](https://github.com/SwiftPackageIndex/PackageList/actions/runs/3454712507/jobs/5766224040) due to:

```
ERROR: package dump failed: error: '852dd406-2b6d-4101-aba4-608728cac732': Invalid manifest
/tmp/852DD406-2B6D-4101-ABA4-608728CAC732/Package.swift:35:22: error: cannot find 'excludeFiles' in scope
            exclude: excludeFiles,
                     ^~~~~~~~~~~~
error: invalid manifests at [<AbsolutePath:"/tmp/852DD406-2B6D-4101-ABA4-608728CAC732">]
```