### PR TITLE
Infinite recursion warning #667

### DIFF
--- a/Sources/Core/Utility/Utilities.swift
+++ b/Sources/Core/Utility/Utilities.swift
@@ -114,20 +114,6 @@ public struct Utilities {
 
     /// Formats a BigInt object to String. The supplied number is first divided into integer and decimal part based on "toUnits",
     /// then limit the decimal part to "decimals" symbols and uses a "decimalSeparator" as a separator.
-    ///
-    /// Returns nil of formatting is not possible to satisfy.
-    static func formatToEthereumUnits(_ bigNumber: BigInt, toUnits: Utilities.Units = .eth, decimals: Int = 4, decimalSeparator: String = ".") -> String? {
-        guard let formatted = formatToPrecision(bigNumber, numberDecimals: toUnits.decimals, formattingDecimals: decimals, decimalSeparator: decimalSeparator, fallbackToScientific: false) else { return nil }
-        switch bigNumber.sign {
-        case .plus:
-            return formatted
-        case .minus:
-            return "-" + formatted
-        }
-    }
-
-    /// Formats a BigInt object to String. The supplied number is first divided into integer and decimal part based on "toUnits",
-    /// then limit the decimal part to "decimals" symbols and uses a "decimalSeparator" as a separator.
     /// Fallbacks to scientific format if higher precision is required.
     ///
     /// Returns nil of formatting is not possible to satisfy.
@@ -141,14 +127,6 @@ public struct Utilities {
             return "-" + formatted
         }
     }
-
-//    /// Formats a BigUInt object to String. The supplied number is first divided into integer and decimal part based on "toUnits",
-//    /// then limit the decimal part to "decimals" symbols and uses a "decimalSeparator" as a separator.
-//    ///
-//    /// Returns nil of formatting is not possible to satisfy.
-//    static func formatToEthereumUnits(_ bigNumber: BigUInt, toUnits: Utilities.Units = .eth, decimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String? {
-//        return formatToPrecision(bigNumber, numberDecimals: toUnits.decimals, formattingDecimals: decimals, decimalSeparator: decimalSeparator, fallbackToScientific: fallbackToScientific)
-//    }
 
     /// Formats a BigUInt object to String. The supplied number is first divided into integer and decimal part based on "numberDecimals",
     /// then limits the decimal part to "formattingDecimals" symbols and uses a "decimalSeparator" as a separator.

--- a/Sources/Core/Utility/Utilities.swift
+++ b/Sources/Core/Utility/Utilities.swift
@@ -286,7 +286,7 @@ public struct Utilities {
 
 extension Utilities {
     /// Various units used in Ethereum ecosystem
-    public enum Units: Int {
+    public enum Units {
         case wei
         case kwei
         case babbage
@@ -310,31 +310,34 @@ extension Utilities {
         case mether
         case gether
         case tether
+        case custom(Int)
 
         public var decimals: Int {
             switch self {
-                case .wei:
-                    return 0
-                case .kwei, .babbage, .femtoether:
-                    return 3
-                case .mwei, .lovelace, .picoether:
-                    return 6
-                case .gwei, .shannon, .nanoether, .nano:
-                    return 9
-                case .microether, .szabo, .micro:
-                    return 12
-                case .finney, .milliether, .milli:
-                    return 15
-                case .ether:
-                    return 18
-                case .kether, .grand:
-                    return 21
-                case .mether:
-                    return 24
-                case .gether:
-                    return 27
-                case .tether:
-                    return 30
+            case .wei:
+                return 0
+            case .kwei, .babbage, .femtoether:
+                return 3
+            case .mwei, .lovelace, .picoether:
+                return 6
+            case .gwei, .shannon, .nanoether, .nano:
+                return 9
+            case .microether, .szabo, .micro:
+                return 12
+            case .finney, .milliether, .milli:
+                return 15
+            case .ether:
+                return 18
+            case .kether, .grand:
+                return 21
+            case .mether:
+                return 24
+            case .gether:
+                return 27
+            case .tether:
+                return 30
+            case .custom(let decimals):
+                return max(0, decimals)
             }
         }
     }

--- a/Sources/Core/Utility/Utilities.swift
+++ b/Sources/Core/Utility/Utilities.swift
@@ -87,7 +87,7 @@ public struct Utilities {
     /// Parse a user-supplied string using the number of decimals for particular Ethereum unit.
     /// If input is non-numeric or precision is not sufficient - returns nil.
     /// Allowed decimal separators are ".", ",".
-    public static func parseToBigUInt(_ amount: String, units: Utilities.Units = .eth) -> BigUInt? {
+    public static func parseToBigUInt(_ amount: String, units: Utilities.Units = .ether) -> BigUInt? {
         let unitDecimals = units.decimals
         return parseToBigUInt(amount, decimals: unitDecimals)
     }
@@ -112,14 +112,14 @@ public struct Utilities {
         return mainPart
     }
 
-    /// Formats a BigInt object to String. The supplied number is first divided into integer and decimal part based on "toUnits",
+    /// Formats a BigInt object to String. The supplied number is first divided into integer and decimal part based on "units",
     /// then limit the decimal part to "decimals" symbols and uses a "decimalSeparator" as a separator.
     /// Fallbacks to scientific format if higher precision is required.
     ///
     /// Returns nil of formatting is not possible to satisfy.
-    public static func formatToPrecision(_ bigNumber: BigInt, numberDecimals: Int = 18, formattingDecimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String? {
+    public static func formatToPrecision(_ bigNumber: BigInt, units: Utilities.Units = .ether, formattingDecimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String {
         let magnitude = bigNumber.magnitude
-        guard let formatted = formatToPrecision(magnitude, numberDecimals: numberDecimals, formattingDecimals: formattingDecimals, decimalSeparator: decimalSeparator, fallbackToScientific: fallbackToScientific) else {return nil}
+        let formatted = formatToPrecision(magnitude, units: units, formattingDecimals: formattingDecimals, decimalSeparator: decimalSeparator, fallbackToScientific: fallbackToScientific)
         switch bigNumber.sign {
         case .plus:
             return formatted
@@ -128,16 +128,16 @@ public struct Utilities {
         }
     }
 
-    /// Formats a BigUInt object to String. The supplied number is first divided into integer and decimal part based on "numberDecimals",
+    /// Formats a BigUInt object to String. The supplied number is first divided into integer and decimal part based on "units",
     /// then limits the decimal part to "formattingDecimals" symbols and uses a "decimalSeparator" as a separator.
     /// Fallbacks to scientific format if higher precision is required.
     ///
     /// Returns nil of formatting is not possible to satisfy.
-    public static func formatToPrecision(_ bigNumber: BigUInt, numberDecimals: Int = 18, formattingDecimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String? {
+    public static func formatToPrecision(_ bigNumber: BigUInt, units: Utilities.Units = .ether, formattingDecimals: Int = 4, decimalSeparator: String = ".", fallbackToScientific: Bool = false) -> String {
         if bigNumber == 0 {
             return "0"
         }
-        let unitDecimals = numberDecimals
+        let unitDecimals = units.decimals
         var toDecimals = formattingDecimals
         if unitDecimals < toDecimals {
             toDecimals = unitDecimals
@@ -286,33 +286,55 @@ public struct Utilities {
 
 extension Utilities {
     /// Various units used in Ethereum ecosystem
-    public enum Units {
-        case eth
+    public enum Units: Int {
         case wei
-        case Kwei
-        case Mwei
-        case Gwei
-        case Microether
-        case Finney
+        case kwei
+        case babbage
+        case femtoether
+        case mwei
+        case lovelace
+        case picoether
+        case gwei
+        case shannon
+        case nanoether
+        case nano
+        case microether
+        case szabo
+        case micro
+        case finney
+        case milliether
+        case milli
+        case ether
+        case kether
+        case grand
+        case mether
+        case gether
+        case tether
 
         public var decimals: Int {
-            get {
-                switch self {
-                case .eth:
-                    return 18
+            switch self {
                 case .wei:
                     return 0
-                case .Kwei:
+                case .kwei, .babbage, .femtoether:
                     return 3
-                case .Mwei:
+                case .mwei, .lovelace, .picoether:
                     return 6
-                case .Gwei:
+                case .gwei, .shannon, .nanoether, .nano:
                     return 9
-                case .Microether:
+                case .microether, .szabo, .micro:
                     return 12
-                case .Finney:
+                case .finney, .milliether, .milli:
                     return 15
-                }
+                case .ether:
+                    return 18
+                case .kether, .grand:
+                    return 21
+                case .mether:
+                    return 24
+                case .gether:
+                    return 27
+                case .tether:
+                    return 30
             }
         }
     }

--- a/Sources/Core/Utility/Utilities.swift
+++ b/Sources/Core/Utility/Utilities.swift
@@ -117,8 +117,7 @@ public struct Utilities {
     ///
     /// Returns nil of formatting is not possible to satisfy.
     static func formatToEthereumUnits(_ bigNumber: BigInt, toUnits: Utilities.Units = .eth, decimals: Int = 4, decimalSeparator: String = ".") -> String? {
-        let magnitude = BigInt(bigNumber.magnitude)
-        guard let formatted = formatToEthereumUnits(magnitude, toUnits: toUnits, decimals: decimals, decimalSeparator: decimalSeparator) else {return nil}
+        guard let formatted = formatToPrecision(bigNumber, numberDecimals: toUnits.decimals, formattingDecimals: decimals, decimalSeparator: decimalSeparator, fallbackToScientific: false) else { return nil }
         switch bigNumber.sign {
         case .plus:
             return formatted

--- a/Sources/web3swift/Utils/ENS/ETHRegistrarController.swift
+++ b/Sources/web3swift/Utils/ENS/ETHRegistrarController.swift
@@ -66,7 +66,7 @@ public extension ENS {
         }
 
         public func registerName(from: EthereumAddress, name: String, owner: EthereumAddress, duration: UInt, secret: String, price: String) throws -> WriteOperation {
-            guard let amount = Utilities.parseToBigUInt(price, units: .eth) else {throw Web3Error.inputError(desc: "Wrong price: no way for parsing to ether units")}
+            guard let amount = Utilities.parseToBigUInt(price, units: .ether) else {throw Web3Error.inputError(desc: "Wrong price: no way for parsing to ether units")}
             defaultOptions.value = amount
             defaultOptions.from = from
             defaultOptions.to = self.address
@@ -75,7 +75,7 @@ public extension ENS {
         }
 
         public func extendNameRegistration(from: EthereumAddress, name: String, duration: UInt32, price: String) throws -> WriteOperation {
-            guard let amount = Utilities.parseToBigUInt(price, units: .eth) else {throw Web3Error.inputError(desc: "Wrong price: no way for parsing to ether units")}
+            guard let amount = Utilities.parseToBigUInt(price, units: .ether) else {throw Web3Error.inputError(desc: "Wrong price: no way for parsing to ether units")}
             defaultOptions.value = amount
             defaultOptions.from = from
             defaultOptions.to = self.address

--- a/Tests/web3swiftTests/localTests/BasicLocalNodeTests.swift
+++ b/Tests/web3swiftTests/localTests/BasicLocalNodeTests.swift
@@ -51,7 +51,7 @@ class BasicLocalNodeTests: LocalTestCase {
         let parameters = [] as [AnyObject]
         let sendTx = contract.createWriteOperation("fallback", parameters: parameters)!
 
-        let valueToSend = Utilities.parseToBigUInt("1.0", units: .eth)!
+        let valueToSend = try XCTUnwrap(Utilities.parseToBigUInt("1.0", units: .ether))
         sendTx.transaction.value = valueToSend
         sendTx.transaction.from = allAddresses[0]
 

--- a/Tests/web3swiftTests/localTests/LocalTestCase.swift
+++ b/Tests/web3swiftTests/localTests/LocalTestCase.swift
@@ -23,7 +23,7 @@ class LocalTestCase: XCTestCase {
         let allAddresses = try! await web3.eth.ownedAccounts()
         let sendToAddress = allAddresses[0]
         let contract = web3.contract(Web3.Utils.coldWalletABI, at: sendToAddress, abiVersion: 2)
-        let value = Utilities.parseToBigUInt("1.0", units: .eth)!
+        let value = try XCTUnwrap(Utilities.parseToBigUInt("1.0", units: .ether))
         let from = allAddresses[0]
         let writeTX = contract!.createWriteOperation("fallback")!
         writeTX.transaction.from = from

--- a/Tests/web3swiftTests/localTests/NumberFormattingUtilTests.swift
+++ b/Tests/web3swiftTests/localTests/NumberFormattingUtilTests.swift
@@ -15,56 +15,61 @@ class NumberFormattingUtilTests: LocalTestCase {
     func testNumberFormattingUtil() throws {
         let balance = BigInt("-1000000000000000000")
         print("this is print")
-        let formatted = Utilities.formatToPrecision(balance, numberDecimals: 18, formattingDecimals: 4, decimalSeparator: ",")
+        let formatted = Utilities.formatToPrecision(balance, units: .ether, formattingDecimals: 4, decimalSeparator: ",")
         XCTAssert(formatted == "-1")
     }
 
     func testNumberFormattingUtil2() throws {
         let balance = BigInt("-1000000000000000")
-        let formatted = Utilities.formatToPrecision(balance, numberDecimals: 18, formattingDecimals: 4, decimalSeparator: ",")
+        let formatted = Utilities.formatToPrecision(balance, units: .ether, formattingDecimals: 4, decimalSeparator: ",")
         XCTAssert(formatted == "-0,0010")
     }
 
     func testNumberFormattingUtil3() throws {
         let balance = BigInt("-1000000000000")
-        let formatted = Utilities.formatToPrecision(balance, numberDecimals: 18, formattingDecimals: 4, decimalSeparator: ",")
+        let formatted = Utilities.formatToPrecision(balance, units: .ether, formattingDecimals: 4, decimalSeparator: ",")
         XCTAssert(formatted == "-0,0000")
     }
 
     func testNumberFormattingUtil4() throws {
         let balance = BigInt("-1000000000000")
-        let formatted = Utilities.formatToPrecision(balance, numberDecimals: 18, formattingDecimals: 9, decimalSeparator: ",")
+        let formatted = Utilities.formatToPrecision(balance, units: .ether, formattingDecimals: 9, decimalSeparator: ",")
         XCTAssert(formatted == "-0,000001000")
     }
 
     func testNumberFormattingUtil5() throws {
         let balance = BigInt("-1")
-        let formatted = Utilities.formatToPrecision(balance, numberDecimals: 18, formattingDecimals: 9, decimalSeparator: ",", fallbackToScientific: true)
+        let formatted = Utilities.formatToPrecision(balance, units: .ether, formattingDecimals: 9, decimalSeparator: ",", fallbackToScientific: true)
         XCTAssert(formatted == "-1e-18")
     }
 
     func testNumberFormattingUtil6() throws {
         let balance = BigInt("0")
-        let formatted = Utilities.formatToPrecision(balance, numberDecimals: 18, formattingDecimals: 9, decimalSeparator: ",")
+        let formatted = Utilities.formatToPrecision(balance, units: .ether, formattingDecimals: 9, decimalSeparator: ",")
         XCTAssert(formatted == "0")
     }
 
     func testNumberFormattingUtil7() throws {
         let balance = BigInt("-1100000000000000000")
-        let formatted = Utilities.formatToPrecision(balance, numberDecimals: 18, formattingDecimals: 4, decimalSeparator: ",")
+        let formatted = Utilities.formatToPrecision(balance, units: .ether, formattingDecimals: 4, decimalSeparator: ",")
         XCTAssert(formatted == "-1,1000")
     }
 
     func testNumberFormattingUtil8() throws {
         let balance = BigInt("100")
-        let formatted = Utilities.formatToPrecision(balance, numberDecimals: 18, formattingDecimals: 4, decimalSeparator: ",", fallbackToScientific: true)
+        let formatted = Utilities.formatToPrecision(balance, units: .ether, formattingDecimals: 4, decimalSeparator: ",", fallbackToScientific: true)
         XCTAssert(formatted == "1,00e-16")
     }
 
     func testNumberFormattingUtil9() throws {
         let balance = BigInt("1000000")
-        let formatted = Utilities.formatToPrecision(balance, numberDecimals: 18, formattingDecimals: 4, decimalSeparator: ",", fallbackToScientific: true)
+        let formatted = Utilities.formatToPrecision(balance, units: .ether, formattingDecimals: 4, decimalSeparator: ",", fallbackToScientific: true)
         XCTAssert(formatted == "1,0000e-12")
     }
-
+    
+    func testFormatPreccissionFallbacksToUnitsDecimals() throws {
+        let bInt = BigInt(1_700_000_000_000_000_000)
+        let result = Utilities.formatToPrecision(bInt, units: .ether, formattingDecimals: Utilities.Units.ether.decimals + 1, decimalSeparator: ",")
+        XCTAssertEqual(result, "1,700000000000000000")
+    }
 }

--- a/Tests/web3swiftTests/localTests/TransactionsTests.swift
+++ b/Tests/web3swiftTests/localTests/TransactionsTests.swift
@@ -632,7 +632,7 @@ class TransactionsTests: XCTestCase {
             let sendToAddress = EthereumAddress("0xe22b8979739D724343bd002F9f432F5990879901")!
             let allAddresses = try await web3.eth.ownedAccounts()
             let contract = web3.contract(Web3.Utils.coldWalletABI, at: sendToAddress, abiVersion: 2)
-            let value = Utilities.parseToBigUInt("1.0", units: .eth)
+            let value = Utilities.parseToBigUInt("1.0", units: .ether)
             let from = allAddresses[0]
             let writeTX = contract!.createWriteOperation("fallback")!
             writeTX.transaction.from = from

--- a/Tests/web3swiftTests/localTests/UtilitiesTests.swift
+++ b/Tests/web3swiftTests/localTests/UtilitiesTests.swift
@@ -1,0 +1,51 @@
+//
+//  UtilitiesTests.swift
+//  
+//
+//  Created by albertopeam on 15/11/22.
+//
+
+import XCTest
+import BigInt
+import Core
+
+@testable import web3swift
+
+class UtilitiesTests: XCTestCase {    
+    // MARK: - units
+    
+    struct Test {
+        let input: Utilities.Units
+        let output: Int
+    }
+    
+    func testUnitsDecimals() throws {
+        let units: [Test] = [.init(input: .wei, output: 0),
+                             .init(input: .kwei, output: 3),
+                             .init(input: .babbage, output: 3),
+                             .init(input: .femtoether, output: 3),
+                             .init(input: .mwei, output: 6),
+                             .init(input: .lovelace, output: 6),
+                             .init(input: .picoether, output: 6),
+                             .init(input: .gwei, output: 9),
+                             .init(input: .shannon, output: 9),
+                             .init(input: .nanoether, output: 9),
+                             .init(input: .nano, output: 9),
+                             .init(input: .szabo, output: 12),
+                             .init(input: .microether, output: 12),
+                             .init(input: .micro, output: 12),
+                             .init(input: .finney, output: 15),
+                             .init(input: .milliether, output: 15),
+                             .init(input: .milli, output: 15),
+                             .init(input: .ether, output: 18),
+                             .init(input: .kether, output: 21),
+                             .init(input: .grand, output: 21),
+                             .init(input: .mether, output: 24),
+                             .init(input: .gether, output: 27),
+                             .init(input: .tether, output: 30),
+        ]
+        units.forEach { test in
+            XCTAssertEqual(test.input.decimals, test.output)
+        }
+    }
+}

--- a/Tests/web3swiftTests/localTests/UtilitiesTests.swift
+++ b/Tests/web3swiftTests/localTests/UtilitiesTests.swift
@@ -1,6 +1,5 @@
 //
 //  UtilitiesTests.swift
-//  
 //
 //  Created by albertopeam on 15/11/22.
 //

--- a/Tests/web3swiftTests/remoteTests/EIP1559Tests.swift
+++ b/Tests/web3swiftTests/remoteTests/EIP1559Tests.swift
@@ -18,7 +18,7 @@ final class EIP1559Tests: XCTestCase {
             type: .eip1559,
             to: EthereumAddress("0xb47292B7bBedA4447564B8336E4eD1f93735e7C7")!,
             chainID: web3.provider.network!.chainID,
-            value: Utilities.parseToBigUInt("0.1", units: .eth)!,
+            value: try XCTUnwrap(Utilities.parseToBigUInt("0.1", units: .ether)),
             gasLimit: 21_000
         )
         // Vitalik's address
@@ -34,7 +34,7 @@ final class EIP1559Tests: XCTestCase {
             type: .eip1559,
             to: EthereumAddress("0xeBec795c9c8bBD61FFc14A6662944748F299cAcf")!,
             chainID: web3.provider.network!.chainID,
-            value: Utilities.parseToBigUInt("0.1", units: .eth)!,
+            value: try XCTUnwrap(Utilities.parseToBigUInt("0.1", units: .ether)),
             gasLimit: 21_000
         )
         // Vitalik's address

--- a/Tests/web3swiftTests/remoteTests/InfuraTests.swift
+++ b/Tests/web3swiftTests/remoteTests/InfuraTests.swift
@@ -15,7 +15,7 @@ class InfuraTests: XCTestCase {
         let web3 = await Web3.InfuraMainnetWeb3(accessToken: Constants.infuraToken)
         let address = EthereumAddress("0xd61b5ca425F8C8775882d4defefC68A6979DBbce")!
         let balance = try await web3.eth.getBalance(for: address)
-        let balString = Utilities.formatToPrecision(balance, numberDecimals: Utilities.Units.eth.decimals, formattingDecimals: 3)
+        let balString = Utilities.formatToPrecision(balance, units: .ether, formattingDecimals: 3)
         XCTAssertNotNil(balString)
     }
 

--- a/Tests/web3swiftTests/remoteTests/PolicyResolverTests.swift
+++ b/Tests/web3swiftTests/remoteTests/PolicyResolverTests.swift
@@ -20,7 +20,7 @@ final class PolicyResolverTests: XCTestCase {
             type: .eip1559,
             to: EthereumAddress("0xb47292B7bBedA4447564B8336E4eD1f93735e7C7")!,
             chainID: web3.provider.network!.chainID,
-            value: Utilities.parseToBigUInt("0.1", units: .eth)!,
+            value: try XCTUnwrap(Utilities.parseToBigUInt("0.1", units: .ether)),
             gasLimit: 21_000
         )
         // Vitalik's address
@@ -42,7 +42,7 @@ final class PolicyResolverTests: XCTestCase {
             type: .legacy,
             to: EthereumAddress("0xb47292B7bBedA4447564B8336E4eD1f93735e7C7")!,
             chainID: web3.provider.network!.chainID,
-            value: Utilities.parseToBigUInt("0.1", units: .eth)!,
+            value: try XCTUnwrap(Utilities.parseToBigUInt("0.1", units: .ether)),
             gasLimit: 21_000
         )
         // Vitalik's address
@@ -67,7 +67,7 @@ final class PolicyResolverTests: XCTestCase {
             type: .eip1559,
             to: EthereumAddress("0xb47292B7bBedA4447564B8336E4eD1f93735e7C7")!,
             chainID: web3.provider.network!.chainID,
-            value: Utilities.parseToBigUInt("0.1", units: .eth)!,
+            value: try XCTUnwrap(Utilities.parseToBigUInt("0.1", units: .ether)),
             gasLimit: 21_000
         )
         // Vitalik's address


### PR DESCRIPTION
I have read the [issue](https://github.com/web3swift-team/web3swift/issues/667) and it seems that the function in Utilities line 149 was commented but the code inside it was not copied to the function that now causes the recursion

Solution: I only forwarded the call from `formatToEthereumUnits` to `formatToPrecision`, which was the same as before introducing the recursion.

Could you take a look? I ran the unit tests but they crashed as it seems that I need a node running locally and I didn't read the doc yet. If you forward me to the doc I will install the env and I will ran the tests properly before submit the PR
