### PR TITLE
fix: deprecated SecurityToken investors function actually expects a uint256 - an index argument

### DIFF
--- a/Sources/web3swift/Tokens/ST20/Web3+SecurityToken.swift
+++ b/Sources/web3swift/Tokens/ST20/Web3+SecurityToken.swift
@@ -28,8 +28,8 @@ protocol ISecurityToken: IST20, IOwnable {
     /// Total number of non-zero token holders
     func investorCount() async throws -> BigUInt
 
-    /// List of token holders
-    func investors() async throws -> [EthereumAddress]
+    /// List of token holders at specified index
+    func investors(index: UInt) async throws -> [EthereumAddress]
 
     /// Permissions this to a Permission module, which has a key of 1
     /// If no Permission return false - note that IModule withPerm will allow ST owner all permissions anyway
@@ -326,10 +326,9 @@ public class SecurityToken: ISecurityToken, ERC20BaseProperties {
         return res
     }
 
-    public func investors() async throws -> [EthereumAddress] {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("investors", parameters: [AnyObject](), extraData: Data() )!.callContractMethod()
+    public func investors(index: UInt) async throws -> [EthereumAddress] {
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("investors", parameters: [index] as [AnyObject])!.callContractMethod()
         guard let res = result["0"] as? [EthereumAddress] else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
         return res
     }


### PR DESCRIPTION
## **Summary of Changes**

SecurityToken ABI located at `Web3.Utils.st20ABI` expects that `investors` function will be called with an argument of type `uint256`. Our implementation of encoding `investors` function call crashed as we gave it no arguments.

More info: `function investors(uint256 _index) external view returns (address)` ([link to the function](https://github.com/PolymathNetwork/polymath-core/blob/2b50c164d39ef27546a15a712d418e0d2f7861be/contracts/interfaces/ISecurityToken.sol#L117) in old version of the contract) was deprecated and is no longer a part of [ISecurityToken.sol](https://github.com/PolymathNetwork/polymath-core/blob/master/contracts/interfaces/ISecurityToken.sol). Instead there are `getInvestors()` and `getInvestorsAt(uint256 _checkpointId)` ([link](https://github.com/PolymathNetwork/polymath-core/blob/master/contracts/interfaces/ISecurityToken.sol#L365)).

Strong advice: if we will add implementations to other smart contracts cover them with links to the source as much as possible.

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
