### PR TITLE
chore: tokens code clean up

### DIFF
--- a/Sources/web3swift/Tokens/ST20/Web3+SecurityToken.swift
+++ b/Sources/web3swift/Tokens/ST20/Web3+SecurityToken.swift
@@ -91,7 +91,7 @@ public class SecurityToken: ISecurityToken, ERC20BaseProperties {
 
     func tokenDetails() async throws -> [UInt32] {
         transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("tokenDetails", parameters: [] as [AnyObject])!.callContractMethod()
+        let result = try await contract.createReadOperation("tokenDetails")!.callContractMethod()
         guard let res = result["0"] as? [UInt32] else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }

--- a/Sources/web3swift/Tokens/ST20/Web3+SecurityToken.swift
+++ b/Sources/web3swift/Tokens/ST20/Web3+SecurityToken.swift
@@ -90,307 +90,256 @@ public class SecurityToken: ISecurityToken, ERC20BaseProperties {
     }
 
     func tokenDetails() async throws -> [UInt32] {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("tokenDetails", parameters: [] as [AnyObject], extraData: Data() )!.callContractMethod()
-        guard let res = result["0"] as? [UInt32] else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("tokenDetails", parameters: [] as [AnyObject])!.callContractMethod()
+        guard let res = result["0"] as? [UInt32] else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }
 
     func verifyTransfer(from: EthereumAddress, originalOwner: EthereumAddress, to: EthereumAddress, amount: String) async throws -> WriteOperation {
-        let contract = self.contract
-
-        self.transaction.from = from
-        self.transaction.to = self.address
-        self.transaction.callOnBlock = .latest
+        transaction.from = from
+        transaction.to = self.address
+        transaction.callOnBlock = .latest
 
         // get the decimals manually
-        let callResult = try await contract.createReadOperation("decimals" )!.callContractMethod()
+        let callResult = try await contract.createReadOperation("decimals")!.callContractMethod()
         var decimals = BigUInt(0)
         guard let dec = callResult["0"], let decTyped = dec as? BigUInt else {
-            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals")}
+            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals") }
         decimals = decTyped
 
         let intDecimals = Int(decimals)
         guard let value = Utilities.parseToBigUInt(amount, decimals: intDecimals) else {
             throw Web3Error.inputError(desc: "Can not parse inputted amount")
         }
-
-        let tx = contract.createWriteOperation("verifyTransfer", parameters: [originalOwner, to, value] as [AnyObject] )!
-        return tx
+        return contract.createWriteOperation("verifyTransfer", parameters: [originalOwner, to, value] as [AnyObject])!
     }
 
     func mint(from: EthereumAddress, investor: EthereumAddress, amount: String) async throws -> WriteOperation {
-        let contract = self.contract
-
-        self.transaction.from = from
-        self.transaction.to = self.address
-        self.transaction.callOnBlock = .latest
+        transaction.from = from
+        transaction.to = self.address
+        transaction.callOnBlock = .latest
 
         // get the decimals manually
-        let callResult = try await contract.createReadOperation("decimals" )!.callContractMethod()
+        let callResult = try await contract.createReadOperation("decimals")!.callContractMethod()
         var decimals = BigUInt(0)
         guard let dec = callResult["0"], let decTyped = dec as? BigUInt else {
-            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals")}
+            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals") }
         decimals = decTyped
 
         let intDecimals = Int(decimals)
         guard let value = Utilities.parseToBigUInt(amount, decimals: intDecimals) else {
             throw Web3Error.inputError(desc: "Can not parse inputted amount")
         }
-
-        let tx = contract.createWriteOperation("mint", parameters: [investor, value] as [AnyObject] )!
-        return tx
+        return contract.createWriteOperation("mint", parameters: [investor, value] as [AnyObject])!
     }
 
     public func burn(from: EthereumAddress, amount: String) async throws -> WriteOperation {
-        let contract = self.contract
-
-        self.transaction.from = from
-        self.transaction.to = self.address
-        self.transaction.callOnBlock = .latest
+        transaction.from = from
+        transaction.to = self.address
+        transaction.callOnBlock = .latest
 
         // get the decimals manually
-        let callResult = try await contract.createReadOperation("decimals" )!.callContractMethod()
+        let callResult = try await contract.createReadOperation("decimals")!.callContractMethod()
         var decimals = BigUInt(0)
         guard let dec = callResult["0"], let decTyped = dec as? BigUInt else {
-            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals")}
+            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals") }
         decimals = decTyped
 
         let intDecimals = Int(decimals)
         guard let value = Utilities.parseToBigUInt(amount, decimals: intDecimals) else {
             throw Web3Error.inputError(desc: "Can not parse inputted amount")
         }
-        let tx = contract.createWriteOperation("burn", parameters: [value] as [AnyObject] )!
-        return tx
+        return contract.createWriteOperation("burn", parameters: [value] as [AnyObject])!
     }
 
     public func getBalance(account: EthereumAddress) async throws -> BigUInt {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("balanceOf", parameters: [account] as [AnyObject], extraData: Data() )!.callContractMethod()
-        guard let res = result["0"] as? BigUInt else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("balanceOf", parameters: [account] as [AnyObject])!.callContractMethod()
+        guard let res = result["0"] as? BigUInt else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }
 
     public func getAllowance(originalOwner: EthereumAddress, delegate: EthereumAddress) async throws -> BigUInt {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("allowance", parameters: [originalOwner, delegate] as [AnyObject], extraData: Data() )!.callContractMethod()
-        guard let res = result["0"] as? BigUInt else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("allowance", parameters: [originalOwner, delegate] as [AnyObject])!.callContractMethod()
+        guard let res = result["0"] as? BigUInt else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }
 
     public func transfer(from: EthereumAddress, to: EthereumAddress, amount: String) async throws -> WriteOperation {
-        let contract = self.contract
-
-        self.transaction.from = from
-        self.transaction.to = self.address
-        self.transaction.callOnBlock = .latest
+        transaction.from = from
+        transaction.to = self.address
+        transaction.callOnBlock = .latest
 
         // get the decimals manually
-        let callResult = try await contract.createReadOperation("decimals" )!.callContractMethod()
+        let callResult = try await contract.createReadOperation("decimals")!.callContractMethod()
         var decimals = BigUInt(0)
         guard let dec = callResult["0"], let decTyped = dec as? BigUInt else {
-            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals")}
+            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals") }
         decimals = decTyped
 
         let intDecimals = Int(decimals)
         guard let value = Utilities.parseToBigUInt(amount, decimals: intDecimals) else {
             throw Web3Error.inputError(desc: "Can not parse inputted amount")
         }
-        let tx = contract.createWriteOperation("transfer", parameters: [to, value] as [AnyObject] )!
-        return tx
+        return contract.createWriteOperation("transfer", parameters: [to, value] as [AnyObject])!
     }
 
     public func transferFrom(from: EthereumAddress, to: EthereumAddress, originalOwner: EthereumAddress, amount: String) async throws -> WriteOperation {
-        let contract = self.contract
-
-        self.transaction.from = from
-        self.transaction.to = self.address
-        self.transaction.callOnBlock = .latest
+        transaction.from = from
+        transaction.to = self.address
+        transaction.callOnBlock = .latest
 
         // get the decimals manually
-        let callResult = try await contract.createReadOperation("decimals" )!.callContractMethod()
+        let callResult = try await contract.createReadOperation("decimals")!.callContractMethod()
         var decimals = BigUInt(0)
         guard let dec = callResult["0"], let decTyped = dec as? BigUInt else {
-            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals")}
+            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals") }
         decimals = decTyped
 
         let intDecimals = Int(decimals)
         guard let value = Utilities.parseToBigUInt(amount, decimals: intDecimals) else {
             throw Web3Error.inputError(desc: "Can not parse inputted amount")
         }
-
-        let tx = contract.createWriteOperation("transferFrom", parameters: [originalOwner, to, value] as [AnyObject] )!
-        return tx
+        return contract.createWriteOperation("transferFrom", parameters: [originalOwner, to, value] as [AnyObject])!
     }
 
     public func setAllowance(from: EthereumAddress, to: EthereumAddress, newAmount: String) async throws -> WriteOperation {
-        let contract = self.contract
-
-        self.transaction.from = from
-        self.transaction.to = self.address
-        self.transaction.callOnBlock = .latest
+        transaction.from = from
+        transaction.to = self.address
+        transaction.callOnBlock = .latest
 
         // get the decimals manually
-        let callResult = try await contract.createReadOperation("decimals" )!.callContractMethod()
+        let callResult = try await contract.createReadOperation("decimals")!.callContractMethod()
         var decimals = BigUInt(0)
         guard let dec = callResult["0"], let decTyped = dec as? BigUInt else {
-            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals")}
+            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals") }
         decimals = decTyped
 
         let intDecimals = Int(decimals)
         guard let value = Utilities.parseToBigUInt(newAmount, decimals: intDecimals) else {
             throw Web3Error.inputError(desc: "Can not parse inputted amount")
         }
-
-        let tx = contract.createWriteOperation("setAllowance", parameters: [to, value] as [AnyObject] )!
-        return tx
+        return contract.createWriteOperation("setAllowance", parameters: [to, value] as [AnyObject])!
     }
 
     public func approve(from: EthereumAddress, spender: EthereumAddress, amount: String) async throws -> WriteOperation {
-        let contract = self.contract
-
-        self.transaction.from = from
-        self.transaction.to = self.address
-        self.transaction.callOnBlock = .latest
+        transaction.from = from
+        transaction.to = self.address
+        transaction.callOnBlock = .latest
 
         // get the decimals manually
-        let callResult = try await contract.createReadOperation("decimals" )!.callContractMethod()
+        let callResult = try await contract.createReadOperation("decimals")!.callContractMethod()
         var decimals = BigUInt(0)
         guard let dec = callResult["0"], let decTyped = dec as? BigUInt else {
-            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals")}
+            throw Web3Error.inputError(desc: "Contract may be not ERC20 compatible, can not get decimals") }
         decimals = decTyped
 
         let intDecimals = Int(decimals)
         guard let value = Utilities.parseToBigUInt(amount, decimals: intDecimals) else {
             throw Web3Error.inputError(desc: "Can not parse inputted amount")
         }
-
-        let tx = contract.createWriteOperation("approve", parameters: [spender, value] as [AnyObject] )!
-        return tx
+        return contract.createWriteOperation("approve", parameters: [spender, value] as [AnyObject])!
     }
 
     public func totalSupply() async throws -> BigUInt {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("totalSupply", parameters: [AnyObject](), extraData: Data() )!.callContractMethod()
-        guard let res = result["0"] as? BigUInt else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("totalSupply")!.callContractMethod()
+        guard let res = result["0"] as? BigUInt else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }
 
     public func renounceOwnership(from: EthereumAddress) throws -> WriteOperation {
-        let contract = self.contract
-
-        self.transaction.from = from
-        self.transaction.to = self.address
-        self.transaction.callOnBlock = .latest
-
-        let tx = contract.createWriteOperation("renounceOwnership", parameters: [AnyObject]() )!
-        return tx
+        transaction.from = from
+        transaction.to = self.address
+        transaction.callOnBlock = .latest
+        return contract.createWriteOperation("renounceOwnership", parameters: [AnyObject]() )!
     }
 
     public func transferOwnership(from: EthereumAddress, newOwner: EthereumAddress) throws -> WriteOperation {
-        let contract = self.contract
-
-        self.transaction.from = from
-        self.transaction.to = self.address
-        self.transaction.callOnBlock = .latest
-
-        let tx = contract.createWriteOperation("transferOwnership", parameters: [newOwner] as [AnyObject] )!
-        return tx
+        transaction.from = from
+        transaction.to = self.address
+        transaction.callOnBlock = .latest
+        return contract.createWriteOperation("transferOwnership", parameters: [newOwner] as [AnyObject])!
     }
 
     public func currentCheckpointId() async throws -> BigUInt {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("currentCheckpointId", parameters: [AnyObject](), extraData: Data() )!.callContractMethod()
-        guard let res = result["0"] as? BigUInt else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("currentCheckpointId")!.callContractMethod()
+        guard let res = result["0"] as? BigUInt else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }
 
     public func getGranularity() async throws -> BigUInt {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("granularity", parameters: [AnyObject](), extraData: Data() )!.callContractMethod()
-        guard let res = result["0"] as? BigUInt else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("granularity")!.callContractMethod()
+        guard let res = result["0"] as? BigUInt else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }
 
     public func investorCount() async throws -> BigUInt {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("investorCount", parameters: [AnyObject](), extraData: Data() )!.callContractMethod()
-        guard let res = result["0"] as? BigUInt else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("investorCount")!.callContractMethod()
+        guard let res = result["0"] as? BigUInt else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }
 
     public func investors(index: UInt) async throws -> [EthereumAddress] {
         transaction.callOnBlock = .latest
         let result = try await contract.createReadOperation("investors", parameters: [index] as [AnyObject])!.callContractMethod()
-        guard let res = result["0"] as? [EthereumAddress] else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        guard let res = result["0"] as? [EthereumAddress] else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }
 
     public func checkPermission(delegate: EthereumAddress, module: EthereumAddress, perm: [UInt32]) async throws -> Bool {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("checkPermission", parameters: [delegate, module, perm] as [AnyObject], extraData: Data() )!.callContractMethod()
-        guard let res = result["0"] as? Bool else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("checkPermission", parameters: [delegate, module, perm] as [AnyObject])!.callContractMethod()
+        guard let res = result["0"] as? Bool else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }
 
     public func getModule(moduleType: UInt8, moduleIndex: UInt8) async throws -> ([UInt32], EthereumAddress) {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("getModule", parameters: [moduleType, moduleIndex] as [AnyObject], extraData: Data() )!.callContractMethod()
-        guard let moduleList = result["0"] as? [UInt32] else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
-        guard let moduleAddress = result["1"] as? EthereumAddress else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("getModule", parameters: [moduleType, moduleIndex] as [AnyObject])!.callContractMethod()
+        guard let moduleList = result["0"] as? [UInt32] else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
+        guard let moduleAddress = result["1"] as? EthereumAddress else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return (moduleList, moduleAddress)
     }
 
     public func getModuleByName(moduleType: UInt8, name: [UInt32]) async throws -> ([UInt32], EthereumAddress) {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("getModuleByName", parameters: [moduleType, name] as [AnyObject], extraData: Data() )!.callContractMethod()
-        guard let moduleList = result["0"] as? [UInt32] else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
-        guard let moduleAddress = result["1"] as? EthereumAddress else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("getModuleByName", parameters: [moduleType, name] as [AnyObject])!.callContractMethod()
+        guard let moduleList = result["0"] as? [UInt32] else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
+        guard let moduleAddress = result["1"] as? EthereumAddress else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return (moduleList, moduleAddress)
     }
 
     public func totalSupplyAt(checkpointId: BigUInt) async throws -> BigUInt {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("totalSupplyAt", parameters: [checkpointId] as [AnyObject], extraData: Data() )!.callContractMethod()
-        guard let res = result["0"] as? BigUInt else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("totalSupplyAt", parameters: [checkpointId] as [AnyObject])!.callContractMethod()
+        guard let res = result["0"] as? BigUInt else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }
 
     public func balanceOfAt(investor: EthereumAddress, checkpointId: BigUInt) async throws -> BigUInt {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("balanceOfAt", parameters: [investor, checkpointId] as [AnyObject], extraData: Data() )!.callContractMethod()
-        guard let res = result["0"] as? BigUInt else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("balanceOfAt", parameters: [investor, checkpointId] as [AnyObject])!.callContractMethod()
+        guard let res = result["0"] as? BigUInt else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }
 
     public func createCheckpoint(from: EthereumAddress) throws -> WriteOperation {
-        let contract = self.contract
-
-        self.transaction.from = from
-        self.transaction.to = self.address
-        self.transaction.callOnBlock = .latest
-
-        let tx = contract.createWriteOperation("createCheckpoint", parameters: [AnyObject]() )!
-        return tx
+        transaction.from = from
+        transaction.to = self.address
+        transaction.callOnBlock = .latest
+        return contract.createWriteOperation("createCheckpoint", parameters: [AnyObject]() )!
     }
 
     public func getInvestorsLength() async throws -> BigUInt {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("getInvestorsLength", parameters: [AnyObject](), extraData: Data() )!.callContractMethod()
-        guard let res = result["0"] as? BigUInt else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("getInvestorsLength")!.callContractMethod()
+        guard let res = result["0"] as? BigUInt else { throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node") }
         return res
     }
 }

--- a/Sources/web3swift/Tokens/ST20/Web3+SecurityToken.swift
+++ b/Sources/web3swift/Tokens/ST20/Web3+SecurityToken.swift
@@ -28,8 +28,8 @@ protocol ISecurityToken: IST20, IOwnable {
     /// Total number of non-zero token holders
     func investorCount() async throws -> BigUInt
 
-    /// List of token holders
-    func investors() async throws -> [EthereumAddress]
+    /// List of token holders at specified index
+    func investors(index: UInt) async throws -> [EthereumAddress]
 
     /// Permissions this to a Permission module, which has a key of 1
     /// If no Permission return false - note that IModule withPerm will allow ST owner all permissions anyway
@@ -326,10 +326,9 @@ public class SecurityToken: ISecurityToken, ERC20BaseProperties {
         return res
     }
 
-    public func investors() async throws -> [EthereumAddress] {
-        let contract = self.contract
-        self.transaction.callOnBlock = .latest
-        let result = try await contract.createReadOperation("investors", parameters: [AnyObject](), extraData: Data() )!.callContractMethod()
+    public func investors(index: UInt) async throws -> [EthereumAddress] {
+        transaction.callOnBlock = .latest
+        let result = try await contract.createReadOperation("investors", parameters: [index] as [AnyObject])!.callContractMethod()
         guard let res = result["0"] as? [EthereumAddress] else {throw Web3Error.processingError(desc: "Failed to get result of expected type from the Ethereum node")}
         return res
     }

--- a/Sources/web3swift/Web3/Web3+Contract.swift
+++ b/Sources/web3swift/Web3/Web3+Contract.swift
@@ -53,14 +53,14 @@ extension Web3 {
         ///
         /// Returns a "Transaction intermediate" object.
         public func prepareDeploy(bytecode: Data,
-                           constructor: ABI.Element.Constructor? = nil,
-                           parameters: [AnyObject]? = nil,
-                           extraData: Data? = nil) -> WriteOperation? {
+                                  constructor: ABI.Element.Constructor? = nil,
+                                  parameters: [AnyObject]? = nil,
+                                  extraData: Data? = nil) -> WriteOperation? {
             // MARK: Writing Data flow
             guard let data = self.contract.deploy(bytecode: bytecode,
-                                                constructor: constructor,
-                                                parameters: parameters,
-                                                extraData: extraData)
+                                                  constructor: constructor,
+                                                  parameters: parameters,
+                                                  extraData: extraData)
             else { return nil }
 
             if let network = self.web3.provider.network {
@@ -71,9 +71,9 @@ extension Web3 {
             transaction.data = data
             transaction.to = .contractDeploymentAddress()
 
-            return WriteOperation(transaction: self.transaction,
-                                  web3: self.web3,
-                                  contract: self.contract)
+            return WriteOperation(transaction: transaction,
+                                  web3: web3,
+                                  contract: contract)
         }
 
         // FIXME: Actually this is not rading contract or smth, this is about composing appropriate binary data to iterate with it later.
@@ -86,11 +86,11 @@ extension Web3 {
         /// Returns a "Transaction intermediate" object.
         public func createReadOperation(_ method: String = "fallback", parameters: [AnyObject] = [AnyObject](), extraData: Data = Data()) -> ReadOperation? {
             // MARK: - Encoding ABI Data flow
-            guard let data = self.contract.method(method, parameters: parameters, extraData: extraData) else { return nil }
+            guard let data = contract.method(method, parameters: parameters, extraData: extraData) else { return nil }
 
             transaction.data = data
 
-            if let network = self.web3.provider.network {
+            if let network = web3.provider.network {
                 transaction.chainID = network.chainID
             }
 
@@ -106,12 +106,12 @@ extension Web3 {
         ///
         /// Returns a "Transaction intermediate" object.
         public func createWriteOperation(_ method: String = "fallback", parameters: [AnyObject] = [AnyObject](), extraData: Data = Data()) -> WriteOperation? {
-            guard let data = self.contract.method(method, parameters: parameters, extraData: extraData) else {return nil}
+            guard let data = contract.method(method, parameters: parameters, extraData: extraData) else { return nil }
             transaction.data = data
-            if let network = self.web3.provider.network {
+            if let network = web3.provider.network {
                 transaction.chainID = network.chainID
             }
-            return .init(transaction: transaction, web3: self.web3, contract: self.contract, method: method)
+            return .init(transaction: transaction, web3: web3, contract: contract, method: method)
         }
     }
 }


### PR DESCRIPTION
## **Summary of Changes**
Only available for review after #704 is merged as they share 1 commit.
Just cleaning some code. Spacing, indents, redundant lines of code like `let contract = self.contract`.

What has been done:
- removed `parameters: [AnyObject](), extraData: Data()` from all `createReadOperation` calls as these are default values;
- added spacing between `{}` and the code inside;
- removed redundant `self.` uses;
- removed `let contract = self.contract` lines;
- and instead of 
```
let tx = contract.createWriteOperation("setAllowance", parameters: [to, value] as [AnyObject] )!
return tx
```
just returning a result of `contract.create...`.

&nbsp;

## **Test Data or Screenshots**

&nbsp;

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
