### PR TITLE
chore: remove &nbsp; from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,8 @@
 ## **Summary of Changes**
 
-
 Fixes # _(if applicable - add the number of issue this PR addresses)_
 
-&nbsp;
-
 ## **Test Data or Screenshots**
-
-&nbsp;
 
 ###### _By submitting this pull request, you are confirming the following:_
 


### PR DESCRIPTION
## **Summary of Changes**

Just a suggestion (we can close this PR if you won't approve it).
IMHO, it looks better without extra space in the description.
Before:

<img width="1005" alt="Screenshot 2022-12-08 at 19 11 55" src="https://user-images.githubusercontent.com/36865532/206519320-80d55806-b01c-4cb8-b66f-a819c0345ce2.png">

After:

<img width="976" alt="Screenshot 2022-12-08 at 19 12 12" src="https://user-images.githubusercontent.com/36865532/206519369-0ef68f20-1847-4e33-a794-5f60b3c6bc36.png">


## **Test Data or Screenshots**

&nbsp;

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
