### PR TITLE
`ERC20.transaction` doesn't assigns to `WriteOperation.transaction` property fix

### DIFF
--- a/Sources/web3swift/Tokens/ERC20/Web3+ERC20.swift
+++ b/Sources/web3swift/Tokens/ERC20/Web3+ERC20.swift
@@ -108,7 +108,6 @@ public class ERC20: IERC20, ERC20BaseProperties {
     }
 
     public func setAllowance(from: EthereumAddress, to: EthereumAddress, newAmount: String) async throws -> WriteOperation {
-        let contract = self.contract
         self.transaction.from = from
         self.transaction.to = self.address
         self.transaction.callOnBlock = .latest
@@ -126,7 +125,7 @@ public class ERC20: IERC20, ERC20BaseProperties {
         guard let value = Utilities.parseToBigUInt(newAmount, decimals: intDecimals) else {
             throw Web3Error.inputError(desc: "Can not parse inputted amount")
         }
-
+        contract.transaction = transaction
         let tx = contract.createWriteOperation("setAllowance", parameters: [to, value] as [AnyObject] )!
         return tx
     }
@@ -155,7 +154,6 @@ public class ERC20: IERC20, ERC20BaseProperties {
     }
 
     public func totalSupply() async throws -> BigUInt {
-        let contract = self.contract
         self.transaction.callOnBlock = .latest
         let result = try await contract
             .createReadOperation("totalSupply", parameters: [AnyObject](), extraData: Data() )!

--- a/Sources/web3swift/Tokens/ERC20/Web3+ERC20.swift
+++ b/Sources/web3swift/Tokens/ERC20/Web3+ERC20.swift
@@ -62,7 +62,6 @@ public class ERC20: IERC20, ERC20BaseProperties {
     }
 
     public func transfer(from: EthereumAddress, to: EthereumAddress, amount: String) async throws -> WriteOperation {
-        let contract = self.contract
         self.transaction.from = from
         self.transaction.to = self.address
         self.transaction.callOnBlock = .latest
@@ -80,12 +79,12 @@ public class ERC20: IERC20, ERC20BaseProperties {
         guard let value = Utilities.parseToBigUInt(amount, decimals: intDecimals) else {
             throw Web3Error.inputError(desc: "Can not parse inputted amount")
         }
+        contract.transaction = transaction
         let tx = contract.createWriteOperation("transfer", parameters: [to, value] as [AnyObject] )!
         return tx
     }
 
     public func transferFrom(from: EthereumAddress, to: EthereumAddress, originalOwner: EthereumAddress, amount: String) async throws -> WriteOperation {
-        let contract = self.contract
         self.transaction.from = from
         self.transaction.to = self.address
         self.transaction.callOnBlock = .latest
@@ -103,7 +102,7 @@ public class ERC20: IERC20, ERC20BaseProperties {
         guard let value = Utilities.parseToBigUInt(amount, decimals: intDecimals) else {
             throw Web3Error.inputError(desc: "Can not parse inputted amount")
         }
-
+        contract.transaction = transaction
         let tx = contract.createWriteOperation("transferFrom", parameters: [originalOwner, to, value] as [AnyObject] )!
         return tx
     }
@@ -133,7 +132,6 @@ public class ERC20: IERC20, ERC20BaseProperties {
     }
 
     public func approve(from: EthereumAddress, spender: EthereumAddress, amount: String) async throws -> WriteOperation {
-        let contract = self.contract
         self.transaction.from = from
         self.transaction.to = self.address
         self.transaction.callOnBlock = .latest
@@ -151,7 +149,7 @@ public class ERC20: IERC20, ERC20BaseProperties {
         guard let value = Utilities.parseToBigUInt(amount, decimals: intDecimals) else {
             throw Web3Error.inputError(desc: "Can not parse inputted amount")
         }
-
+        contract.transaction = transaction
         let tx = contract.createWriteOperation("approve", parameters: [spender, value] as [AnyObject] )!
         return tx
     }


### PR DESCRIPTION
This one fixing the ERC20 implementation bug, where `ERC20.transaction` never assigns to `Contract.transaction` for any given method that writes on chain.

Obviously it's a bug spreading all over the `Token` implementation. So this fix should be applied to all `ERC*.swift` methods that returns `WriteOperation`.

This is the special case of #712.

Closes #711