### PR TITLE
Add convenience init for Web3HttpProvider

### DIFF
--- a/Sources/web3swift/Web3/Web3+HttpProvider.swift
+++ b/Sources/web3swift/Web3/Web3+HttpProvider.swift
@@ -41,12 +41,12 @@ public class Web3HttpProvider: Web3Provider {
     }
     
     public init(
-        _ httpProviderURL: URL,
-        network net: Networks,
-        keystoreManager manager: KeystoreManager? = nil
+        url: URL,
+        network: Networks,
+        keystoreManager: KeystoreManager? = nil
     ) {
-        url = httpProviderURL
-        network = net
-        attachedKeystoreManager = manager
+        self.url = url
+        self.network = network
+        self.attachedKeystoreManager = keystoreManager
     }
 }

--- a/Sources/web3swift/Web3/Web3+HttpProvider.swift
+++ b/Sources/web3swift/Web3/Web3+HttpProvider.swift
@@ -39,4 +39,14 @@ public class Web3HttpProvider: Web3Provider {
         }
         attachedKeystoreManager = manager
     }
+    
+    public init(
+        _ httpProviderURL: URL,
+        network net: Networks,
+        keystoreManager manager: KeystoreManager? = nil
+    ) {
+        url = httpProviderURL
+        network = net
+        attachedKeystoreManager = manager
+    }
 }

--- a/Sources/web3swift/Web3/Web3+HttpProvider.swift
+++ b/Sources/web3swift/Web3/Web3+HttpProvider.swift
@@ -40,11 +40,7 @@ public class Web3HttpProvider: Web3Provider {
         attachedKeystoreManager = manager
     }
     
-    public init(
-        url: URL,
-        network: Networks,
-        keystoreManager: KeystoreManager? = nil
-    ) {
+    public init(url: URL, network: Networks, keystoreManager: KeystoreManager? = nil) {
         self.url = url
         self.network = network
         self.attachedKeystoreManager = keystoreManager


### PR DESCRIPTION
## **Summary of Changes**

Adds the ability to initialise `Web3HttpProvider` sync and non optionally.

## **Test Data or Screenshots**

Motivation: no need to make init sync and optional if client is sure the network provider is working. 

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
