### PR TITLE
ENSTests added assertions

### DIFF
--- a/Tests/web3swiftTests/remoteTests/ENSTests.swift
+++ b/Tests/web3swiftTests/remoteTests/ENSTests.swift
@@ -12,8 +12,8 @@ import Web3Core
 class ENSTests: XCTestCase {
 
     func testDomainNormalization() throws {
-        let normalizedString = NameHash.normalizeDomainName("example.ens")
-        
+        let normalizedString = NameHash.normalizeDomainName("Example.ENS")
+        XCTAssertEqual(normalizedString, "example.ens")
     }
 
     func testNameHash() throws {
@@ -79,10 +79,10 @@ class ENSTests: XCTestCase {
 
     func testTTL() async throws {
         let web3 = await Web3.InfuraMainnetWeb3(accessToken: Constants.infuraToken)
-        let ens = ENS(web3: web3)
+        let ens = try XCTUnwrap(ENS(web3: web3))
         let domain = "somename.eth"
-        let ttl = try await ens?.registry.getTTL(node: domain)
-        
+        let ttl = try await ens.registry.getTTL(node: domain)
+        XCTAssertGreaterThanOrEqual(ttl, 0)
     }
 
     func testGetAddress() async throws {


### PR DESCRIPTION
## **Summary of Changes**

Added assertions to ENSTests, related to #716 

`testDomainNormalization` lacks the assertion, easy to fix.
`testTTL`  lacks also the assertion, I were checking [EIP137](https://eips.ethereum.org/EIPS/eip-137) and doing some checks with other lib(web3js) and the TTL was zero for "somename.eth". The point here to add this assertion is:
1. ttl will be 0 or greater
2. if something fails it will trigger an exception
The only way to verify a non zero TTL is to change the cache time(TTL) via setter and then run the getter, but being in the mainnet it will generate costs in terms of eth. What do you think?


## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
