### PR TITLE
Rename default options

### DIFF
--- a/Sources/web3swift/Utils/ENS/ENS.swift
+++ b/Sources/web3swift/Utils/ENS/ENS.swift
@@ -74,8 +74,7 @@ public class ENS {
         self.reverseRegistrar = reverseRegistrar
     }
 
-    // FIXME: Rewrite this to CodableTransaction
-    lazy var defaultOptions: CodableTransaction = {
+    lazy var defaultTransaction: CodableTransaction = {
         return CodableTransaction.emptyTransaction
     }()
 
@@ -107,7 +106,7 @@ public class ENS {
         guard isAddrSupports else {
             throw Web3Error.processingError(desc: "Address isn't supported")
         }
-        var options = options ?? defaultOptions
+        var options = options ?? defaultTransaction
         options.to = resolver.resolverContractAddress
         guard let result = try? await resolver.setAddress(forNode: node, address: address, options: options, password: password) else {
             throw Web3Error.processingError(desc: "Can't get result")
@@ -142,7 +141,7 @@ public class ENS {
         guard isNameSupports else {
             throw Web3Error.processingError(desc: "Name isn't supported")
         }
-        var options = options ?? defaultOptions
+        var options = options ?? defaultTransaction
         options.to = resolver.resolverContractAddress
         guard let result = try? await resolver.setCanonicalName(forNode: node, name: name, options: options, password: password) else {
             throw Web3Error.processingError(desc: "Can't get result")
@@ -178,7 +177,7 @@ public class ENS {
         guard isContentSupports else {
             throw Web3Error.processingError(desc: "Content isn't supported")
         }
-        var options = options ?? defaultOptions
+        var options = options ?? defaultTransaction
         options.to = resolver.resolverContractAddress
         guard let result = try? await resolver.setContentHash(forNode: node, hash: hash, options: options, password: password) else {
             throw Web3Error.processingError(desc: "Can't get result")
@@ -213,7 +212,7 @@ public class ENS {
         guard isABISupports else {
             throw Web3Error.processingError(desc: "ABI isn't supported")
         }
-        var options = options ?? defaultOptions
+        var options = options ?? defaultTransaction
         options.to = resolver.resolverContractAddress
         guard let result = try? await resolver.setContractABI(forNode: node, contentType: contentType, data: data, options: options, password: password) else {
             throw Web3Error.processingError(desc: "Can't get result")
@@ -248,7 +247,7 @@ public class ENS {
         guard isPKSupports else {
             throw Web3Error.processingError(desc: "Public Key isn't supported")
         }
-        var options = options ?? defaultOptions
+        var options = options ?? defaultTransaction
         options.to = resolver.resolverContractAddress
         guard let result = try? await resolver.setPublicKey(forNode: node, publicKey: publicKey, options: options, password: password) else {
             throw Web3Error.processingError(desc: "Can't get result")
@@ -283,7 +282,7 @@ public class ENS {
         guard isTextSupports else {
             throw Web3Error.processingError(desc: "Text isn't supported")
         }
-        var options = options ?? defaultOptions
+        var options = options ?? defaultTransaction
         options.to = resolver.resolverContractAddress
         guard let result = try? await resolver.setTextData(forNode: node, key: key, value: value, options: options, password: password) else {
             throw Web3Error.processingError(desc: "Can't get result")

--- a/Sources/web3swift/Utils/ENS/ENSBaseRegistrar.swift
+++ b/Sources/web3swift/Utils/ENS/ENSBaseRegistrar.swift
@@ -12,7 +12,7 @@ import Web3Core
 // FIXME: Rewrite this to CodableTransaction
 public extension ENS {
     class BaseRegistrar: ERC721 {
-        lazy var defaultOptions: CodableTransaction = {
+        lazy var defaultTransaction: CodableTransaction = {
             return CodableTransaction.emptyTransaction
         }()
 
@@ -34,24 +34,24 @@ public extension ENS {
 
         @available(*, message: "Available for only owner")
         public func addController(from: EthereumAddress, controllerAddress: EthereumAddress) throws -> WriteOperation {
-            defaultOptions.from = from
-            defaultOptions.to = self.address
+            defaultTransaction.from = from
+            defaultTransaction.to = self.address
             guard let transaction = self.contract.createWriteOperation("addController", parameters: [controllerAddress as AnyObject], extraData: Data()) else {throw Web3Error.transactionSerializationError}
             return transaction
         }
 
         @available(*, message: "Available for only owner")
         public func removeController(from: EthereumAddress, controllerAddress: EthereumAddress) throws -> WriteOperation {
-            defaultOptions.from = from
-            defaultOptions.to = self.address
+            defaultTransaction.from = from
+            defaultTransaction.to = self.address
             guard let transaction = self.contract.createWriteOperation("removeController", parameters: [controllerAddress as AnyObject], extraData: Data()) else {throw Web3Error.transactionSerializationError}
             return transaction
         }
 
         @available(*, message: "Available for only owner")
         public func setResolver(from: EthereumAddress, resolverAddress: EthereumAddress) throws -> WriteOperation {
-            defaultOptions.from = from
-            defaultOptions.to = self.address
+            defaultTransaction.from = from
+            defaultTransaction.to = self.address
             guard let transaction = self.contract.createWriteOperation("setResolver", parameters: [resolverAddress as AnyObject], extraData: Data()) else {throw Web3Error.transactionSerializationError}
             return transaction
         }
@@ -72,8 +72,8 @@ public extension ENS {
         }
 
         public func reclaim(from: EthereumAddress, record: BigUInt) throws -> WriteOperation {
-            defaultOptions.from = from
-            defaultOptions.to = self.address
+            defaultTransaction.from = from
+            defaultTransaction.to = self.address
             guard let transaction = self.contract.createWriteOperation("reclaim", parameters: [record as AnyObject], extraData: Data()) else {throw Web3Error.transactionSerializationError}
             return transaction
         }

--- a/Sources/web3swift/Utils/ENS/ENSRegistry.swift
+++ b/Sources/web3swift/Utils/ENS/ENSRegistry.swift
@@ -35,8 +35,7 @@ public extension ENS {
             }
         }
 
-        // FIXME: Rewrite this to CodableTransaction
-        lazy var defaultOptions: CodableTransaction = {
+        lazy var defaultTransaction: CodableTransaction = {
             return CodableTransaction.emptyTransaction
         }()
 
@@ -72,7 +71,7 @@ public extension ENS {
 
         // FIXME: Rewrite this to CodableTransaction
         public func setOwner(node: String, owner: EthereumAddress, options: CodableTransaction?, password: String) async throws -> TransactionSendingResult {
-            var options = options ?? defaultOptions
+            var options = options ?? defaultTransaction
             if let contractAddress = self.registryContractAddress {
                 options.to = contractAddress
             }
@@ -84,7 +83,7 @@ public extension ENS {
 
         // FIXME: Rewrite this to CodableTransaction
         public func setSubnodeOwner(node: String, label: String, owner: EthereumAddress, options: CodableTransaction?, password: String) async throws -> TransactionSendingResult {
-            var options = options ?? defaultOptions
+            var options = options ?? defaultTransaction
             if let contractAddress = self.registryContractAddress {
                 options.to = contractAddress
             }
@@ -97,7 +96,7 @@ public extension ENS {
 
         // FIXME: Rewrite this to CodableTransaction
         public func setResolver(node: String, resolver: EthereumAddress, options: CodableTransaction?, password: String) async throws -> TransactionSendingResult {
-            var options = options ?? defaultOptions
+            var options = options ?? defaultTransaction
             if let contractAddress = self.registryContractAddress {
                 options.to = contractAddress
             }
@@ -109,7 +108,7 @@ public extension ENS {
 
         // FIXME: Rewrite this to CodableTransaction
         public func setTTL(node: String, ttl: BigUInt, options: CodableTransaction?, password: String) async throws -> TransactionSendingResult {
-            var options = options ?? defaultOptions
+            var options = options ?? defaultTransaction
             if let contractAddress = self.registryContractAddress {
                 options.to = contractAddress
             }

--- a/Sources/web3swift/Utils/ENS/ENSResolver.swift
+++ b/Sources/web3swift/Utils/ENS/ENSResolver.swift
@@ -51,8 +51,7 @@ public extension ENS {
             return contract!
         }()
 
-        // FIXME: Rewrite this to CodableTransaction
-        lazy var defaultOptions: CodableTransaction = {
+        lazy var defaultTransaction: CodableTransaction = {
             return CodableTransaction.emptyTransaction
         }()
 
@@ -107,7 +106,7 @@ public extension ENS {
         // FIXME: Rewrite this to CodableTransaction
         @available(*, message: "Available for only owner")
         public func setAddress(forNode node: String, address: EthereumAddress, options: CodableTransaction? = nil, password: String) async throws -> TransactionSendingResult {
-            var options = options ?? defaultOptions
+            var options = options ?? defaultTransaction
             options.to = self.resolverContractAddress
             guard let nameHash = NameHash.nameHash(node) else {throw Web3Error.processingError(desc: "Failed to get name hash")}
             guard let transaction = self.resolverContract.createWriteOperation("setAddr", parameters: [nameHash, address] as [AnyObject]) else {throw Web3Error.transactionSerializationError}
@@ -126,7 +125,7 @@ public extension ENS {
         // FIXME: Rewrite this to CodableTransaction
         @available(*, message: "Available for only owner")
         func setCanonicalName(forNode node: String, name: String, options: CodableTransaction? = nil, password: String) async throws -> TransactionSendingResult {
-            var options = options ?? defaultOptions
+            var options = options ?? defaultTransaction
             options.to = self.resolverContractAddress
             guard let nameHash = NameHash.nameHash(node) else {throw Web3Error.processingError(desc: "Failed to get name hash")}
             guard let transaction = self.resolverContract.createWriteOperation("setName", parameters: [nameHash, name] as [AnyObject]) else {throw Web3Error.transactionSerializationError}
@@ -145,7 +144,7 @@ public extension ENS {
         // FIXME: Rewrite this to CodableTransaction
         @available(*, message: "Available for only owner")
         func setContentHash(forNode node: String, hash: String, options: CodableTransaction? = nil, password: String) async throws -> TransactionSendingResult {
-            var options = options ?? defaultOptions
+            var options = options ?? defaultTransaction
             options.to = self.resolverContractAddress
             guard let nameHash = NameHash.nameHash(node) else {throw Web3Error.processingError(desc: "Failed to get name hash")}
             guard let transaction = self.resolverContract.createWriteOperation("setContenthash", parameters: [nameHash, hash] as [AnyObject]) else {throw Web3Error.transactionSerializationError}
@@ -166,7 +165,7 @@ public extension ENS {
         // FIXME: Rewrite this to CodableTransaction
         @available(*, message: "Available for only owner")
         func setContractABI(forNode node: String, contentType: ENS.Resolver.ContentType, data: Data, options: CodableTransaction? = nil, password: String) async throws -> TransactionSendingResult {
-            var options = options ?? defaultOptions
+            var options = options ?? defaultTransaction
             options.to = self.resolverContractAddress
             guard let nameHash = NameHash.nameHash(node) else {throw Web3Error.processingError(desc: "Failed to get name hash")}
             guard let transaction = self.resolverContract.createWriteOperation("setABI", parameters: [nameHash, contentType.rawValue, data] as [AnyObject]) else {throw Web3Error.transactionSerializationError}
@@ -187,7 +186,7 @@ public extension ENS {
         // FIXME: Rewrite this to CodableTransaction
         @available(*, message: "Available for only owner")
         public func setPublicKey(forNode node: String, publicKey: PublicKey, options: CodableTransaction? = nil, password: String) async throws -> TransactionSendingResult {
-            var options = options ?? defaultOptions
+            var options = options ?? defaultTransaction
             options.to = self.resolverContractAddress
             let pubkeyWithoutPrefix = publicKey.getComponentsWithoutPrefix()
             guard let nameHash = NameHash.nameHash(node) else {throw Web3Error.processingError(desc: "Failed to get name hash")}
@@ -207,7 +206,7 @@ public extension ENS {
         // FIXME: Rewrite this to CodableTransaction
         @available(*, message: "Available for only owner")
         public func setTextData(forNode node: String, key: String, value: String, options: CodableTransaction? = nil, password: String) async throws -> TransactionSendingResult {
-            var options = options ?? defaultOptions
+            var options = options ?? defaultTransaction
             options.to = self.resolverContractAddress
             guard let nameHash = NameHash.nameHash(node) else {throw Web3Error.processingError(desc: "Failed to get name hash")}
             guard let transaction = self.resolverContract.createWriteOperation("setText", parameters: [nameHash, key, value] as [AnyObject]) else {throw Web3Error.transactionSerializationError}

--- a/Sources/web3swift/Utils/ENS/ENSReverseRegistrar.swift
+++ b/Sources/web3swift/Utils/ENS/ENSReverseRegistrar.swift
@@ -20,8 +20,7 @@ public extension ENS {
             return contract!
         }()
 
-        // FIXME: Rewrite this to CodableTransaction
-        lazy var defaultOptions: CodableTransaction = {
+        lazy var defaultTransaction: CodableTransaction = {
             return CodableTransaction.emptyTransaction
         }()
 
@@ -31,22 +30,22 @@ public extension ENS {
         }
 
         public func claimAddress(from: EthereumAddress, owner: EthereumAddress) throws -> WriteOperation {
-            defaultOptions.from = from
-            defaultOptions.to = self.address
+            defaultTransaction.from = from
+            defaultTransaction.to = self.address
             guard let transaction = self.contract.createWriteOperation("claim", parameters: [owner as AnyObject], extraData: Data()) else {throw Web3Error.transactionSerializationError}
             return transaction
         }
 
         public func claimAddressWithResolver(from: EthereumAddress, owner: EthereumAddress, resolver: EthereumAddress) throws -> WriteOperation {
-            defaultOptions.from = from
-            defaultOptions.to = self.address
+            defaultTransaction.from = from
+            defaultTransaction.to = self.address
             guard let transaction = self.contract.createWriteOperation("claimWithResolver", parameters: [owner, resolver] as [AnyObject], extraData: Data()) else {throw Web3Error.transactionSerializationError}
             return transaction
         }
 
         public func setName(from: EthereumAddress, name: String) throws -> WriteOperation {
-            defaultOptions.from = from
-            defaultOptions.to = self.address
+            defaultTransaction.from = from
+            defaultTransaction.to = self.address
             guard let transaction = self.contract.createWriteOperation("setName", parameters: [name] as [AnyObject], extraData: Data()) else {throw Web3Error.transactionSerializationError}
             return transaction
         }

--- a/Sources/web3swift/Utils/ENS/ETHRegistrarController.swift
+++ b/Sources/web3swift/Utils/ENS/ETHRegistrarController.swift
@@ -20,8 +20,7 @@ public extension ENS {
             return contract!
         }()
 
-        // FIXME: Rewrite this to CodableTransaction
-        lazy var defaultOptions: CodableTransaction = {
+        lazy var defaultTransaction: CodableTransaction = {
             return CodableTransaction.emptyTransaction
         }()
 
@@ -59,34 +58,34 @@ public extension ENS {
         }
 
         public func sumbitCommitment(from: EthereumAddress, commitment: Data) throws -> WriteOperation {
-            defaultOptions.from = from
-            defaultOptions.to = self.address
+            defaultTransaction.from = from
+            defaultTransaction.to = self.address
             guard let transaction = self.contract.createWriteOperation("commit", parameters: [commitment as AnyObject], extraData: Data()) else {throw Web3Error.transactionSerializationError}
             return transaction
         }
 
         public func registerName(from: EthereumAddress, name: String, owner: EthereumAddress, duration: UInt, secret: String, price: String) throws -> WriteOperation {
             guard let amount = Utilities.parseToBigUInt(price, units: .ether) else {throw Web3Error.inputError(desc: "Wrong price: no way for parsing to ether units")}
-            defaultOptions.value = amount
-            defaultOptions.from = from
-            defaultOptions.to = self.address
+            defaultTransaction.value = amount
+            defaultTransaction.from = from
+            defaultTransaction.to = self.address
             guard let transaction = self.contract.createWriteOperation("register", parameters: [name, owner.address, duration, secret] as [AnyObject], extraData: Data()) else {throw Web3Error.transactionSerializationError}
             return transaction
         }
 
         public func extendNameRegistration(from: EthereumAddress, name: String, duration: UInt32, price: String) throws -> WriteOperation {
             guard let amount = Utilities.parseToBigUInt(price, units: .ether) else {throw Web3Error.inputError(desc: "Wrong price: no way for parsing to ether units")}
-            defaultOptions.value = amount
-            defaultOptions.from = from
-            defaultOptions.to = self.address
+            defaultTransaction.value = amount
+            defaultTransaction.from = from
+            defaultTransaction.to = self.address
             guard let transaction = self.contract.createWriteOperation("renew", parameters: [name, duration] as [AnyObject], extraData: Data()) else {throw Web3Error.transactionSerializationError}
             return transaction
         }
 
         @available(*, message: "Available for only owner")
         public func withdraw(from: EthereumAddress) throws -> WriteOperation {
-            defaultOptions.from = from
-            defaultOptions.to = self.address
+            defaultTransaction.from = from
+            defaultTransaction.to = self.address
             guard let transaction = self.contract.createWriteOperation("withdraw", parameters: [AnyObject](), extraData: Data()) else {throw Web3Error.transactionSerializationError}
             return transaction
         }


### PR DESCRIPTION
## **Summary of Changes**

Fixes #728

* Renames `defaultOptions` to `defaultTransaction` on multiple ENS-related classes.

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
