### PR TITLE
Example project remove pod install warnings

### DIFF
--- a/Example/myWeb3Wallet/Podfile
+++ b/Example/myWeb3Wallet/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '15.0'
 
 target 'myWeb3Wallet' do
   # Comment the next line if you don't want to use dynamic frameworks

--- a/Example/myWeb3Wallet/Podfile
+++ b/Example/myWeb3Wallet/Podfile
@@ -19,3 +19,12 @@ pod 'web3swift', :git => 'https://github.com/veerChauhan/web3swift.git', :branch
   end
 
 end
+
+# set iOS deployment target for every pod to avoid warnings
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
+    end
+  end
+end

--- a/Example/myWeb3Wallet/myWeb3Wallet.xcodeproj/project.pbxproj
+++ b/Example/myWeb3Wallet/myWeb3Wallet.xcodeproj/project.pbxproj
@@ -754,7 +754,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6018FABA256C0117F85A829 /* Pods-myWeb3Wallet-myWeb3WalletUITests.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = VPS9LBWQ55;
@@ -778,7 +778,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7574A738941D92CC94F93A9E /* Pods-myWeb3Wallet-myWeb3WalletUITests.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = VPS9LBWQ55;


### PR DESCRIPTION
## **Summary of Changes**

Fixes Example project pod install command warnings

## **Test Data or Screenshots**

Fetch the branch code
Make a `pod install` without warnings
Open `Example/myWeb3Wallet/myWeb3Wallet.xcworkspace` and make a build without warnings from the Pod project

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
