### PR TITLE
test: added test cases for `func publicToAddress`

### DIFF
--- a/Tests/web3swiftTests/localTests/UtilitiesTests.swift
+++ b/Tests/web3swiftTests/localTests/UtilitiesTests.swift
@@ -47,4 +47,39 @@ class UtilitiesTests: XCTestCase {
             XCTAssertEqual(test.input.decimals, test.output)
         }
     }
+
+    func testPublicKeyWithNoPrefixToAddress() throws {
+        var address = Utilities.publicToAddress(Data.fromHex("0x18ed2e1ec629e2d3dae7be1103d4f911c24e0c80e70038f5eb5548245c475f504c220d01e1ca419cb1ba4b3393b615e99dd20aa6bf071078f70fd949008e7411")!)?.address
+        XCTAssertEqual(address, "0x28828f43df370651AC5A6cFd02fBD0885Fbb3c00")
+        address = Utilities.publicToAddress(Data.fromHex("0x52972572d465d016d4c501887b8df303eee3ed602c056b1eb09260dfa0da0ab288742f4dc97d9edb6fd946babc002fdfb06f26caf117b9405ed79275763fdb1c")!)?.address
+        XCTAssertEqual(address, "0x6eDBe1F6D48FbF1b053D6c9FA7997C710B84f55F")
+    }
+
+    func testPublicKeyWithPrefixToAddress() throws {
+        var address = Utilities.publicToAddress(Data.fromHex("0x0418ed2e1ec629e2d3dae7be1103d4f911c24e0c80e70038f5eb5548245c475f504c220d01e1ca419cb1ba4b3393b615e99dd20aa6bf071078f70fd949008e7411")!)?.address
+        XCTAssertEqual(address, "0x28828f43df370651AC5A6cFd02fBD0885Fbb3c00")
+        address = Utilities.publicToAddress(Data.fromHex("0x0452972572d465d016d4c501887b8df303eee3ed602c056b1eb09260dfa0da0ab288742f4dc97d9edb6fd946babc002fdfb06f26caf117b9405ed79275763fdb1c")!)?.address
+        XCTAssertEqual(address, "0x6eDBe1F6D48FbF1b053D6c9FA7997C710B84f55F")
+    }
+
+    func testPublicKeyWithInvalidPrefixToAddress() throws {
+        var address = Utilities.publicToAddress(Data.fromHex("0x0318ed2e1ec629e2d3dae7be1103d4f911c24e0c80e70038f5eb5548245c475f504c220d01e1ca419cb1ba4b3393b615e99dd20aa6bf071078f70fd949008e7411")!)?.address
+        XCTAssertEqual(address, nil)
+        address = Utilities.publicToAddress(Data.fromHex("0x0152972572d465d016d4c501887b8df303eee3ed602c056b1eb09260dfa0da0ab288742f4dc97d9edb6fd946babc002fdfb06f26caf117b9405ed79275763fdb1c")!)?.address
+        XCTAssertEqual(address, nil)
+    }
+
+    func testCompressedPublicKeyToAddress() throws {
+        var address = Utilities.publicToAddress(Data.fromHex("0x0318ed2e1ec629e2d3dae7be1103d4f911c24e0c80e70038f5eb5548245c475f50")!)?.address
+        XCTAssertEqual(address, "0x28828f43df370651AC5A6cFd02fBD0885Fbb3c00")
+        address = Utilities.publicToAddress(Data.fromHex("0x0252972572d465d016d4c501887b8df303eee3ed602c056b1eb09260dfa0da0ab2")!)?.address
+        XCTAssertEqual(address, "0x6eDBe1F6D48FbF1b053D6c9FA7997C710B84f55F")
+    }
+
+    func testCompressedPublicKeyWithInvalidPrefixToAddress() throws {
+        var address = Utilities.publicToAddress(Data.fromHex("0x0718ed2e1ec629e2d3dae7be1103d4f911c24e0c80e70038f5eb5548245c475f50")!)?.address
+        XCTAssertEqual(address, nil)
+        address = Utilities.publicToAddress(Data.fromHex("0x0852972572d465d016d4c501887b8df303eee3ed602c056b1eb09260dfa0da0ab2")!)?.address
+        XCTAssertEqual(address, nil)
+    }
 }


### PR DESCRIPTION
## **Summary of Changes**

Triggered by https://github.com/web3swift-team/web3swift/pull/747
Test cases for the derivation of an Ethereum address from a public key.

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
