### PR TITLE
fix: attempt to encode uint with a negative value results in a crash

### DIFF
--- a/Sources/Web3Core/EthereumABI/ABIEncoding.swift
+++ b/Sources/Web3Core/EthereumABI/ABIEncoding.swift
@@ -218,19 +218,11 @@ public struct ABIEncoder {
     public static func encodeSingleType(type: ABI.Element.ParameterType, value: AnyObject) -> Data? {
         switch type {
         case .uint:
-            if let biguint = convertToBigUInt(value) {
-                return biguint.abiEncode(bits: 256)
-            }
-            if let bigint = convertToBigInt(value) {
-                return bigint.abiEncode(bits: 256)
-            }
+            let biguint = convertToBigUInt(value)
+            return biguint == nil ? nil : biguint!.abiEncode(bits: 256)
         case .int:
-            if let biguint = convertToBigUInt(value) {
-                return biguint.abiEncode(bits: 256)
-            }
-            if let bigint = convertToBigInt(value) {
-                return bigint.abiEncode(bits: 256)
-            }
+            let bigint = convertToBigInt(value)
+            return bigint == nil ? nil : bigint!.abiEncode(bits: 256)
         case .address:
             if let string = value as? String {
                 guard let address = EthereumAddress(string) else {return nil}

--- a/Tests/web3swiftTests/localTests/ABIEncoderTest.swift
+++ b/Tests/web3swiftTests/localTests/ABIEncoderTest.swift
@@ -14,6 +14,16 @@ import BigInt
 
 class ABIEncoderTest: XCTestCase {
 
+    func testEncodeInt() {
+        XCTAssertEqual(ABIEncoder.encodeSingleType(type: .int(bits: 32), value: -10 as AnyObject)?.toHexString(), "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6")
+        XCTAssertEqual(ABIEncoder.encodeSingleType(type: .int(bits: 32), value: 10 as AnyObject)?.toHexString(), "000000000000000000000000000000000000000000000000000000000000000a")
+    }
+
+    func testEncodeUInt() {
+        XCTAssertEqual(ABIEncoder.encodeSingleType(type: .uint(bits: 32), value: -10 as AnyObject), nil)
+        XCTAssertEqual(ABIEncoder.encodeSingleType(type: .uint(bits: 32), value: 10 as AnyObject)?.toHexString(), "000000000000000000000000000000000000000000000000000000000000000a")
+    }
+
     func testSoliditySha3() throws {
         var hex = try ABIEncoder.soliditySha3(true).toHexString().addHexPrefix()
         assert(hex == "0x5fe7f977e71dba2ea1a68e21057beebb9be2ac30c6410aa38d4f3fbe41dcffd2")


### PR DESCRIPTION
## **Summary of Changes**

### Update

The initial bug was caught by mistake by using older version of the web3swift library.
But nonetheless an encoding bug was fixed: passing negative value to `ABIEncoder.encodeSingleType` with a type `.uint` must return `nil`.
For example, web3js produces `Uncaught Error: value out-of-bounds` for such cases. We are returning `nil` for now.

-----------------
Attempts to encode a negative number with ParameterType `.uint(...)` resulted in a crash.
~The fix is located in `ABIEncoder.convertToBigUInt`.~

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
