### PR TITLE
fix: swiftlint configuration file

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,7 +10,9 @@ disabled_rules:
   - identifier_name
   - line_length
   - multiple_closures_with_trailing_closure
-  - todo
+  - todo  
+  - function_parameter_count
+  - nesting
 
 opt_in_rules:
  - weak_delegate
@@ -34,12 +36,12 @@ force_try: error
 
 custom_rules:
   commented_out_code: 
-    included: ".*\\.swift" # regex that defines paths to include during linting. optional.
-    excluded: ".*Test(s)?\\.swift" # regex that defines paths to exclude during linting. optional
-    name: "Commented out code" # rule name. optional.
-    regex: "^\\/\\/\\s*(@|\\.?([a-z]|(\\})))" # matching pattern
+    included: .*\.swift # regex that defines paths to include during linting. optional.
+    excluded: .*Test(s)?\.swift # regex that defines paths to exclude during linting. optional
+    name: Commented out code # rule name. optional.
+    regex: ^\s*(\/\/(?!\s*swiftlint:).*|\/\*[\s\S]*?\*\/) # matching pattern
     capture_group: 0 # number of regex capture group to highlight the rule violation at. optional.
     match_kinds: # SyntaxKinds to match. optional.
       - comment
-    message: "No commented code in devel branch allowed." # violation message. optional.
+    message: No commented code in devel branch allowed. # violation message. optional.
     severity: warning # violation severity. optional.


### PR DESCRIPTION
## **Summary of Changes**

Only SwiftLint config file changes.
- excluded some rules that will force us to introduce breaking changes;
- fixed `commented_out_code` rule. It was triggered by `// swiflint:...` comments that are used to enable/disable SwiftLint rules in code.

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
