### PR TITLE
overload send request method

### DIFF
--- a/Sources/Web3Core/EthereumNetwork/Request/APIRequest+Methods.swift
+++ b/Sources/Web3Core/EthereumNetwork/Request/APIRequest+Methods.swift
@@ -14,7 +14,12 @@ extension APIRequest {
         return try await APIRequest.send(uRLRequest: request, with: provider.session)
     }
 
-    public static func setupRequest(for call: APIRequest, with provider: Web3Provider) -> URLRequest {
+    public static func sendRequest(with provider: Web3Provider, for call: APIRequest) async throws -> Data {
+        let request = setupRequest(for: call, with: provider)
+        return try await APIRequest.send(uRLRequest: request, with: provider.session)
+    }
+
+    static func setupRequest(for call: APIRequest, with provider: Web3Provider) -> URLRequest {
         var urlRequest = URLRequest(url: provider.url, cachePolicy: .reloadIgnoringCacheData)
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")

--- a/Sources/Web3Core/EthereumNetwork/Request/APIRequest+Methods.swift
+++ b/Sources/Web3Core/EthereumNetwork/Request/APIRequest+Methods.swift
@@ -1,6 +1,6 @@
 //
 //  APIRequest+Methods.swift
-//  
+//
 //
 //  Created by Yaroslav Yashin on 12.07.2022.
 //
@@ -14,7 +14,7 @@ extension APIRequest {
         return try await APIRequest.send(uRLRequest: request, with: provider.session)
     }
 
-    static func setupRequest(for call: APIRequest, with provider: Web3Provider) -> URLRequest {
+    public static func setupRequest(for call: APIRequest, with provider: Web3Provider) -> URLRequest {
         var urlRequest = URLRequest(url: provider.url, cachePolicy: .reloadIgnoringCacheData)
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -23,7 +23,7 @@ extension APIRequest {
         return urlRequest
     }
 
-    public static func send<Result>(uRLRequest: URLRequest, with session: URLSession) async throws -> APIResponse<Result> {
+    public static func send(uRLRequest: URLRequest, with session: URLSession) async throws -> Data {
         let (data, response) = try await session.data(for: uRLRequest)
 
         guard 200 ..< 400 ~= response.statusCode else {
@@ -48,6 +48,12 @@ extension APIRequest {
                 throw Web3Error.nodeError(desc: description)
             }
         }
+
+        return data
+    }
+
+    public static func send<Result>(uRLRequest: URLRequest, with session: URLSession) async throws -> APIResponse<Result> {
+        let data = try await send(uRLRequest: uRLRequest, with: session)
 
         /// This bit of code is purposed to work with literal types that comes in ``Response`` in hexString type.
         /// Currently it's just `Data` and any kind of Integers `(U)Int`, `Big(U)Int`.


### PR DESCRIPTION
## **Summary of Changes**
overload `APIRequest.sendRequest`
```
extension APIRequest {
    public static func sendRequest<Result>(with provider: Web3Provider, for call: APIRequest) async throws -> APIResponse<Result>
    public static func sendRequest(with provider: Web3Provider, for call: APIRequest) async throws -> Data
}
```

separate `public static func send<Result>(uRLRequest: URLRequest, with session: URLSession) async throws -> APIResponse<Result>` to two method so caller can get original data

### usage scenario
I need to handle eth requests from webview which used `ethers.js` and encode a struct like `TransactionReceipt` to JSON dictionary is too complicated

I think https://github.com/web3swift-team/web3swift/pull/763 is not necessary now so I closed it.

### sample
```
import Web3Core
import web3swift

struct GetTransactionReceiptHandler {
    @InjectedProvider(\.web3) var web3

    func handleRequest(_ params: Array<AnyObject>) async throws -> AnyObject {
        guard let txHash = params[0] as? String else {
            throw Web3Error.typeError
        }
        let request = APIRequest.getTransactionReceipt(txHash)
        let response: Data = try await APIRequest.sendRequest(with: web3.provider, for: request)
        let dict = try JSONSerialization.jsonObject(with: response) as! [String : AnyObject]

        return dict["result"] as AnyObject
    }
}

```

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
