### PR TITLE
chore: hashECRecover and personalECRecover are identical except 1 line

### DIFF
--- a/Sources/Web3Core/Utility/Utilities.swift
+++ b/Sources/Web3Core/Utility/Utilities.swift
@@ -206,22 +206,8 @@ public struct Utilities {
     ///
     /// Input parameters should be Data objects.
     public static func personalECRecover(_ personalMessage: Data, signature: Data) -> EthereumAddress? {
-        if signature.count != 65 { return nil}
-        let rData = signature[0..<32].bytes
-        let sData = signature[32..<64].bytes
-        var vData = signature[64]
-        if vData >= 27 && vData <= 30 {
-            vData -= 27
-        } else if vData >= 31 && vData <= 34 {
-            vData -= 31
-        } else if vData >= 35 && vData <= 38 {
-            vData -= 35
-        }
-
-        guard let signatureData = SECP256K1.marshalSignature(v: vData, r: rData, s: sData) else { return nil }
         guard let hash = Utilities.hashPersonalMessage(personalMessage) else { return nil }
-        guard let publicKey = SECP256K1.recoverPublicKey(hash: hash, signature: signatureData) else { return nil }
-        return Utilities.publicToAddress(publicKey)
+        return hashECRecover(hash: hash, signature: signature)
     }
 
     /// Recover the Ethereum address from recoverable secp256k1 signature.


### PR DESCRIPTION
## **Summary of Changes**

Removed redundant code as two functions `hashECRecover` and `personalECRecover` have identical code except for 1 line that calculates a hash from the message in `personalECRecover`.

<img width="1166" alt="Screenshot 2023-02-11 at 18 20 16" src="https://user-images.githubusercontent.com/36865532/218269157-e029c48b-327d-422f-8538-9fc37a04ddef.png">


## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
