### PR TITLE
Minor: description of transaction doesn't return from

### DIFF
--- a/Sources/Web3Core/EthereumAddress/EthereumAddress.swift
+++ b/Sources/Web3Core/EthereumAddress/EthereumAddress.swift
@@ -155,3 +155,16 @@ extension EthereumAddress: Codable {
 extension EthereumAddress: Hashable { }
 
 extension EthereumAddress: APIResultType { }
+
+// MARK: - CustomStringConvertible
+
+extension EthereumAddress: CustomStringConvertible {
+    /// Used when converting an instance to a string
+    public var description: String {
+        var toReturn = ""
+        toReturn += "EthereumAddress" + "\n"
+        toReturn += "type: " + String(describing: type) + "\n"
+        toReturn += "address: " + String(describing: address) + "\n"
+        return toReturn
+    }
+}

--- a/Sources/Web3Core/Transaction/CodableTransaction.swift
+++ b/Sources/Web3Core/Transaction/CodableTransaction.swift
@@ -271,7 +271,7 @@ extension CodableTransaction: CustomStringConvertible {
         var toReturn = ""
         toReturn += "Transaction" + "\n"
         toReturn += String(describing: self.envelope)
-        toReturn += "from: " + String(describing: self.sender?.address)  + "\n"
+        toReturn += "from: " + String(describing: self.sender)  + "\n"
         toReturn += "hash: " + String(describing: self.hash?.toHexString().addHexPrefix()) + "\n"
         return toReturn
     }

--- a/Tests/web3swiftTests/localTests/EthereumAddressTest.swift
+++ b/Tests/web3swiftTests/localTests/EthereumAddressTest.swift
@@ -1,6 +1,6 @@
 //
 //  EthereumAddressTest.swift
-//  
+//
 //
 //  Created by JeneaVranceanu on 03.02.2023.
 //
@@ -35,4 +35,15 @@ class EthereumAddressTest: XCTestCase {
         XCTAssertNil(ethereumAddress)
     }
 
+    func testDescription() async throws {
+        let rawAddress = "0x200eb5ccda1c35b0f5bf82552fdd65a8aee98e79"
+        let ethereumAddress = EthereumAddress(rawAddress)
+
+        let sut = String(describing: ethereumAddress)
+        print(sut)
+
+        XCTAssertTrue(sut.contains("EthereumAddress\n"))
+        XCTAssertTrue(sut.contains("type: normal\n"))
+        XCTAssertTrue(sut.contains("address: 0x"))
+    }
 }

--- a/Tests/web3swiftTests/localTests/TransactionsTests.swift
+++ b/Tests/web3swiftTests/localTests/TransactionsTests.swift
@@ -592,6 +592,18 @@ class TransactionsTests: XCTestCase {
         }
     }
 
+    func testDescription() async throws {
+        let vector = testVector[TestCase.eip1559.rawValue]
+        let jsonData = try XCTUnwrap(vector.JSON.data(using: .utf8))
+        let txn = try JSONDecoder().decode(CodableTransaction.self, from: jsonData)
+
+        let sut = String(describing: txn)
+
+        XCTAssertTrue(sut.contains("Transaction"))
+        XCTAssertTrue(sut.contains("from: "))
+        XCTAssertTrue(sut.contains("hash: "))
+    }
+
     // ***** Legacy Tests *****
     // TODO: Replace `XCTAssert` with more explicit `XCTAssertEqual`, where Applicable
 


### PR DESCRIPTION
## **Summary of Changes**
added EthereumAddress conformance to CustomStringConvertible. 
added sender to CustomStringConvertible for CodableTransaction

Fixes # _(if applicable - add the number of issue this PR addresses)_
Related to #766

## **Test Data or Screenshots**
Added a pair of tests to verify that the data is appended, not verified the content itself. 

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
