### PR TITLE
SwiftLint recommends a double run when fixing

### DIFF
--- a/.github/workflows/macOS-tests.yml
+++ b/.github/workflows/macOS-tests.yml
@@ -42,7 +42,10 @@ jobs:
       - name: SwiftLint
         run: |
           # Adding --fix flag makes CI print only errors that cannot be fixed automatically
-          swiftlint --fix
+          # 1. Make automated fixes that are possible
+          # 2. git diff to see what automated fixes were made
+          # 3. See https://github.com/realm/SwiftLint#xcode explains why the double run
+          swiftlint --fix && git diff && swiftlint
       - name: Resolve dependencies
         run: swift package resolve
       - name: Build

--- a/.github/workflows/macOS-tests.yml
+++ b/.github/workflows/macOS-tests.yml
@@ -44,7 +44,7 @@ jobs:
           # 1. Make automated fixes that are possible
           # 2. git diff to see what automated fixes were made
           # 3. See https://github.com/realm/SwiftLint#xcode explains why the double run
-          swiftlint --fix && git branch && git status && git diff origin/${GITHUB_REF} origin/${GITHUB_HEAD_REF} && swiftlint
+          echo "test" > target.txt && swiftlint --fix && git branch && git status && git diff && swiftlint
       - name: Resolve dependencies
         run: swift package resolve
       - name: Build

--- a/.github/workflows/macOS-tests.yml
+++ b/.github/workflows/macOS-tests.yml
@@ -41,10 +41,10 @@ jobs:
           codespell  # See .codespellrc for args
       - name: SwiftLint
         run: |
-          # 1. Make automated fixes that are possible
-          # 2. git diff to see what automated fixes were made
+          # 1. Make all automated fixes that are possible
+          # 2. git diff to see what (if any) automated fixes were made
           # 3. See https://github.com/realm/SwiftLint#xcode explains why the double run
-          swiftlint --fix && git diff && swiftlint
+          swiftlint --fix --quiet && git diff && swiftlint --quiet
       - name: Resolve dependencies
         run: swift package resolve
       - name: Build

--- a/.github/workflows/macOS-tests.yml
+++ b/.github/workflows/macOS-tests.yml
@@ -44,7 +44,7 @@ jobs:
           # 1. Make automated fixes that are possible
           # 2. git diff to see what automated fixes were made
           # 3. See https://github.com/realm/SwiftLint#xcode explains why the double run
-          swiftlint --fix && git diff origin/${GITHUB_REF##*/} origin/${GITHUB_HEAD_REF} && swiftlint
+          swiftlint --fix && git diff origin/develop origin/${GITHUB_HEAD_REF} && swiftlint
       - name: Resolve dependencies
         run: swift package resolve
       - name: Build

--- a/.github/workflows/macOS-tests.yml
+++ b/.github/workflows/macOS-tests.yml
@@ -44,7 +44,7 @@ jobs:
           # 1. Make automated fixes that are possible
           # 2. git diff to see what automated fixes were made
           # 3. See https://github.com/realm/SwiftLint#xcode explains why the double run
-          swiftlint --fix && git diff origin/develop origin/${GITHUB_HEAD_REF} && swiftlint
+          swiftlint --fix && git branch && git status && git diff origin/${GITHUB_REF} origin/${GITHUB_HEAD_REF} && swiftlint
       - name: Resolve dependencies
         run: swift package resolve
       - name: Build

--- a/.github/workflows/macOS-tests.yml
+++ b/.github/workflows/macOS-tests.yml
@@ -34,8 +34,6 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 2  # Enable `git diff` in GitHub Actions
       - name: Discover typos
         run: |
           pip3 install --upgrade pip
@@ -46,7 +44,7 @@ jobs:
           # 1. Make automated fixes that are possible
           # 2. git diff to see what automated fixes were made
           # 3. See https://github.com/realm/SwiftLint#xcode explains why the double run
-          swiftlint --fix && git diff && swiftlint
+          swiftlint --fix && git diff origin/${GITHUB_REF##*/} origin/${GITHUB_HEAD_REF} && swiftlint
       - name: Resolve dependencies
         run: swift package resolve
       - name: Build

--- a/.github/workflows/macOS-tests.yml
+++ b/.github/workflows/macOS-tests.yml
@@ -44,7 +44,7 @@ jobs:
           # 1. Make automated fixes that are possible
           # 2. git diff to see what automated fixes were made
           # 3. See https://github.com/realm/SwiftLint#xcode explains why the double run
-          echo "test" > target.txt && swiftlint --fix && git branch && git status && git diff && swiftlint
+          swiftlint --fix && git diff && swiftlint
       - name: Resolve dependencies
         run: swift package resolve
       - name: Build

--- a/.github/workflows/macOS-tests.yml
+++ b/.github/workflows/macOS-tests.yml
@@ -34,6 +34,8 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2  # Enable `git diff` in GitHub Actions
       - name: Discover typos
         run: |
           pip3 install --upgrade pip

--- a/.github/workflows/macOS-tests.yml
+++ b/.github/workflows/macOS-tests.yml
@@ -43,7 +43,6 @@ jobs:
           codespell  # See .codespellrc for args
       - name: SwiftLint
         run: |
-          # Adding --fix flag makes CI print only errors that cannot be fixed automatically
           # 1. Make automated fixes that are possible
           # 2. git diff to see what automated fixes were made
           # 3. See https://github.com/realm/SwiftLint#xcode explains why the double run

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -60,10 +60,6 @@ opt_in_rules:
   - unneeded_parentheses_in_closure_argument
   - weak_delegate
 
-# force warnings (disabled above)
-# force_cast: error
-# force_try: error
-
 custom_rules:
   commented_out_code:
     included: .*\.swift # regex that defines paths to include during linting. optional.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -60,9 +60,9 @@ opt_in_rules:
   - unneeded_parentheses_in_closure_argument
   - weak_delegate
 
-# force warnings
-force_cast: error
-force_try: error
+# force warnings (disabled above)
+# force_cast: error
+# force_try: error
 
 custom_rules:
   commented_out_code:


### PR DESCRIPTION
https://github.com/realm/SwiftLint#xcode recommends
> If you wish to fix violations as well, your script could run `swiftlint --fix && swiftlint` instead of just `swiftlint`. This will mean that all correctable violations are fixed while ensuring warnings show up in your project for remaining violations.

https://github.com/realm/SwiftLint#auto-correct
> Standard linting is disabled while correcting because of the high likelihood of violations (or their offsets) being incorrect after modifying a file while applying corrections.

## **Summary of Changes**

Fixes # _(if applicable - add the number of issue this PR addresses)_

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
