### PR TITLE
fix: init Web3HttpProvider without chain id

### DIFF
--- a/Sources/Web3Core/EthereumNetwork/Request/APIRequest+ComputedProperties.swift
+++ b/Sources/Web3Core/EthereumNetwork/Request/APIRequest+ComputedProperties.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension APIRequest {
-    var method: REST {
+    public var method: REST {
          .POST
     }
 

--- a/Sources/Web3Core/EthereumNetwork/Request/APIRequest+UtilityTypes.swift
+++ b/Sources/Web3Core/EthereumNetwork/Request/APIRequest+UtilityTypes.swift
@@ -14,7 +14,7 @@ public struct APIResponse<Result>: Decodable where Result: APIResultType {
     public var result: Result
 }
 
-enum REST: String {
+public enum REST: String {
     case POST
     case GET
 }

--- a/Sources/web3swift/Web3/Web3+HttpProvider.swift
+++ b/Sources/web3swift/Web3/Web3+HttpProvider.swift
@@ -36,7 +36,7 @@ public class Web3HttpProvider: Web3Provider {
             var urlRequest = URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData)
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
             urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-            urlRequest.httpMethod = APIRequest.getNetwork.call
+            urlRequest.httpMethod = APIRequest.getNetwork.method.rawValue
             urlRequest.httpBody = APIRequest.getNetwork.encodedBody
             let response: APIResponse<UInt> = try await APIRequest.send(uRLRequest: urlRequest, with: session)
             self.network = Networks.fromInt(response.result)


### PR DESCRIPTION
## **Summary of Changes**

Fixes HTTP method

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
