### PR TITLE
feat: sign without hash

### DIFF
--- a/Sources/web3swift/Web3/Web3+Signing.swift
+++ b/Sources/web3swift/Web3/Web3+Signing.swift
@@ -23,11 +23,18 @@ public struct Web3Signer {
                                                                 keystore: T,
                                                                 account: EthereumAddress,
                                                                 password: String,
+                                                                useHash: Bool,
                                                                 useExtraEntropy: Bool = false) throws -> Data? {
         var privateKey = try keystore.UNSAFE_getPrivateKeyData(password: password, account: account)
         defer { Data.zero(&privateKey) }
-        guard let hash = Utilities.hashPersonalMessage(personalMessage) else { return nil }
-        let (compressedSignature, _) = SECP256K1.signForRecovery(hash: hash,
+        var data: Data
+        if useHash {
+            guard let hash = Utilities.hashPersonalMessage(personalMessage) else { return nil }
+            data = hash
+        } else {
+            data = personalMessage
+        }
+        let (compressedSignature, _) = SECP256K1.signForRecovery(hash: data,
                                                                  privateKey: privateKey,
                                                                  useExtraEntropy: useExtraEntropy)
         return compressedSignature

--- a/Sources/web3swift/Web3/Web3+Signing.swift
+++ b/Sources/web3swift/Web3/Web3+Signing.swift
@@ -23,7 +23,7 @@ public struct Web3Signer {
                                                                 keystore: T,
                                                                 account: EthereumAddress,
                                                                 password: String,
-                                                                useHash: Bool,
+                                                                useHash: Bool = true,
                                                                 useExtraEntropy: Bool = false) throws -> Data? {
         var privateKey = try keystore.UNSAFE_getPrivateKeyData(password: password, account: account)
         defer { Data.zero(&privateKey) }


### PR DESCRIPTION
## **Summary of Changes**

For signing, add bool value using  hash or not .
There is the same bool argument for Web3j for Java.
This PR will help collaborate with Java developers.