### PR TITLE
Addresses generator (#1)

### DIFF
--- a/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
@@ -162,7 +162,7 @@ public class BIP32Keystore: AbstractKeystore {
 
     public func createNewCustomChildAccount(password: String, path: String) throws {
         guard let decryptedRootNode = try getPrefixNodeData(password),
-              let keystoreParams = keystoreParams else {
+              let keystoreParams else {
             throw AbstractKeystoreError.encryptionError("Failed to decrypt a keystore")
         }
         guard let rootNode = HDNode(decryptedRootNode) else {
@@ -179,17 +179,17 @@ public class BIP32Keystore: AbstractKeystore {
                 throw AbstractKeystoreError.encryptionError("out of bounds")
             }
 
-            guard var pathAppendix = pathAppendix else {
+            guard let modifiedAppendix = pathAppendix else {
                 throw AbstractKeystoreError.encryptionError("Derivation depth mismatch")
             }
-            if pathAppendix.hasPrefix("/") {
-                pathAppendix = pathAppendix.trimmingCharacters(in: CharacterSet.init(charactersIn: "/"))
+            if modifiedAppendix.hasPrefix("/") {
+                pathAppendix = modifiedAppendix.trimmingCharacters(in: CharacterSet.init(charactersIn: "/"))
             }
         } else if path.hasPrefix("/") {
             pathAppendix = path.trimmingCharacters(in: CharacterSet.init(charactersIn: "/"))
         }
 
-        guard let pathAppendix = pathAppendix,
+        guard let pathAppendix,
               rootNode.depth == prefixPath.components(separatedBy: "/").count - 1 else {
             throw AbstractKeystoreError.encryptionError("Derivation depth mismatch")
         }

--- a/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
@@ -217,13 +217,12 @@ public class BIP32Keystore: AbstractKeystore {
     }
     
     /// Fast generation addresses for current account
-    /// used for shows wich address user wiil get when changed number of his wallet
+    /// used for shows which address user will get when changed number of his wallet
     /// - Parameters:
     ///   - password: password of seed storage
-    ///   - preffixPath: preffix of Derivation Path without account number
-    ///   - number: number of wallets adresses needed to generate from 0 to number-1
+    ///   - number: number of wallets addresses needed to generate from 0 to number-1
     /// - Returns: Array of addresses generated from 0 to number bound, or empty array in case of error
-    public func getAddressForAccount(password: String, preffixPath: String, number: Int) -> [EthereumAddress] {
+    public func getAddressForAccount(password: String, number: Int) -> [EthereumAddress] {
         guard let decryptedRootNode = try? getPrefixNodeData(password) else {
             return []
         }
@@ -235,7 +234,7 @@ public class BIP32Keystore: AbstractKeystore {
         
         return [Int](0..<number).compactMap({ number in
             pathAppendix = nil
-            let path = preffixPath + "/\(number)"
+            let path = prefixPath + "/\(number)"
             if path.hasPrefix(prefixPath) {
                 let upperIndex = (path.range(of: prefixPath)?.upperBound)!
                 if upperIndex < path.endIndex {

--- a/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
@@ -215,7 +215,7 @@ public class BIP32Keystore: AbstractKeystore {
         guard let serializedRootNode = rootNode.serialize(serializePublic: false) else {throw AbstractKeystoreError.keyDerivationError}
         try encryptDataToStorage(password, data: serializedRootNode, aesMode: self.keystoreParams!.crypto.cipher)
     }
-    
+
     /// Fast generation addresses for current account
     /// used for shows which address user will get when changed number of his wallet
     /// - Parameters:
@@ -231,7 +231,7 @@ public class BIP32Keystore: AbstractKeystore {
         }
         let prefixPath = self.rootPrefix
         var pathAppendix: String?
-        
+
         return [Int](0..<number).compactMap({ number in
             pathAppendix = nil
             let path = prefixPath + "/\(number)"
@@ -242,7 +242,7 @@ public class BIP32Keystore: AbstractKeystore {
                 } else {
                     return nil
                 }
-                
+
                 guard pathAppendix != nil else {
                     return nil
                 }
@@ -263,7 +263,7 @@ public class BIP32Keystore: AbstractKeystore {
             return newAddress
         })
     }
-    
+
     fileprivate func encryptDataToStorage(_ password: String, data: Data, dkLen: Int = 32, N: Int = 4096, R: Int = 6, P: Int = 1, aesMode: String = "aes-128-cbc") throws {
         guard data.count == 82 else {
             throw AbstractKeystoreError.encryptionError("Invalid expected data length")

--- a/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
@@ -217,7 +217,7 @@ public class BIP32Keystore: AbstractKeystore {
               let rootNode = HDNode(decryptedRootNode) else {
             throw AbstractKeystoreError.encryptionError("Failed to decrypt a keystore")
         }
-        return try [UInt](0..<number).compactMap() { number in
+        return try [UInt](0..<number).compactMap { number in
             guard rootNode.depth == rootPrefix.components(separatedBy: "/").count - 1,
                   let newNode = rootNode.derive(path: "\(number)", derivePrivateKey: true) else {
                 throw AbstractKeystoreError.keyDerivationError

--- a/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
@@ -230,10 +230,9 @@ public class BIP32Keystore: AbstractKeystore {
             return []
         }
         let prefixPath = self.rootPrefix
-        var pathAppendix: String?
 
-        return [Int](0..<number).compactMap({ number in
-            pathAppendix = nil
+        return [Int](0..<number).compactMap { number in
+            var pathAppendix: String?
             let path = prefixPath + "/\(number)"
             if path.hasPrefix(prefixPath) {
                 let upperIndex = (path.range(of: prefixPath)?.upperBound)!
@@ -261,7 +260,7 @@ public class BIP32Keystore: AbstractKeystore {
                 return nil
             }
             return newAddress
-        })
+        }
     }
 
     fileprivate func encryptDataToStorage(_ password: String, data: Data, dkLen: Int = 32, N: Int = 4096, R: Int = 6, P: Int = 1, aesMode: String = "aes-128-cbc") throws {

--- a/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
@@ -192,12 +192,7 @@ public class BIP32Keystore: AbstractKeystore {
             throw AbstractKeystoreError.keyDerivationError
         }
 
-        let newPath: String
-        if newNode.isHardened {
-            newPath = prefixPath + "/" + pathAppendix.trimmingCharacters(in: .init(charactersIn: "'")) + "'"
-        } else {
-            newPath = prefixPath + "/" + pathAppendix
-        }
+        let newPath = prefixPath + "/" + pathAppendix
 
         addressStorage.add(address: newAddress, for: newPath)
         guard let serializedRootNode = rootNode.serialize(serializePublic: false) else {

--- a/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
@@ -149,14 +149,17 @@ public class BIP32Keystore: AbstractKeystore {
         } else {
             newIndex = UInt32.zero
         }
+
         guard let newNode = parentNode.derive(index: newIndex, derivePrivateKey: true, hardened: false) else {
             throw AbstractKeystoreError.keyDerivationError
         }
         guard let newAddress = Utilities.publicToAddress(newNode.publicKey) else {
             throw AbstractKeystoreError.keyDerivationError
         }
+
         let prefixPath = self.rootPrefix
         var newPath: String
+
         if newNode.isHardened {
             newPath = prefixPath + "/" + String(newNode.index % HDNode.hardenedIndexPrefix) + "'"
         } else {
@@ -166,101 +169,75 @@ public class BIP32Keystore: AbstractKeystore {
     }
 
     public func createNewCustomChildAccount(password: String, path: String) throws {
-        guard let decryptedRootNode = try getPrefixNodeData(password) else {
+        guard let decryptedRootNode = try getPrefixNodeData(password),
+              let keystoreParams = keystoreParams else {
             throw AbstractKeystoreError.encryptionError("Failed to decrypt a keystore")
         }
         guard let rootNode = HDNode(decryptedRootNode) else {
             throw AbstractKeystoreError.encryptionError("Failed to deserialize a root node")
         }
+
         let prefixPath = self.rootPrefix
         var pathAppendix: String?
+
         if path.hasPrefix(prefixPath) {
-            let upperIndex = (path.range(of: prefixPath)?.upperBound)!
-            if upperIndex < path.endIndex {
+            if let upperIndex = (path.range(of: prefixPath)?.upperBound), upperIndex < path.endIndex {
                 pathAppendix = String(path[path.index(after: upperIndex)..<path.endIndex])
             } else {
                 throw AbstractKeystoreError.encryptionError("out of bounds")
             }
 
-            guard pathAppendix != nil else {
+            guard var pathAppendix = pathAppendix else {
                 throw AbstractKeystoreError.encryptionError("Derivation depth mismatch")
             }
-            if pathAppendix!.hasPrefix("/") {
-                pathAppendix = pathAppendix?.trimmingCharacters(in: CharacterSet.init(charactersIn: "/"))
+            if pathAppendix.hasPrefix("/") {
+                pathAppendix = pathAppendix.trimmingCharacters(in: CharacterSet.init(charactersIn: "/"))
             }
-        } else {
-            if path.hasPrefix("/") {
-                pathAppendix = path.trimmingCharacters(in: CharacterSet.init(charactersIn: "/"))
-            }
+        } else if path.hasPrefix("/") {
+            pathAppendix = path.trimmingCharacters(in: CharacterSet.init(charactersIn: "/"))
         }
-        guard pathAppendix != nil else {
+
+        guard let pathAppendix = pathAppendix,
+              rootNode.depth == prefixPath.components(separatedBy: "/").count - 1 else {
             throw AbstractKeystoreError.encryptionError("Derivation depth mismatch")
         }
-        guard rootNode.depth == prefixPath.components(separatedBy: "/").count - 1 else {
-            throw AbstractKeystoreError.encryptionError("Derivation depth mismatch")
-        }
-        guard let newNode = rootNode.derive(path: pathAppendix!, derivePrivateKey: true) else {
+
+        guard let newNode = rootNode.derive(path: pathAppendix, derivePrivateKey: true),
+              let newAddress = Utilities.publicToAddress(newNode.publicKey) else {
             throw AbstractKeystoreError.keyDerivationError
         }
-        guard let newAddress = Utilities.publicToAddress(newNode.publicKey) else {
-            throw AbstractKeystoreError.keyDerivationError
-        }
+
         var newPath: String
         if newNode.isHardened {
-            newPath = prefixPath + "/" + pathAppendix!.trimmingCharacters(in: CharacterSet.init(charactersIn: "'")) + "'"
+            newPath = prefixPath + "/" + pathAppendix.trimmingCharacters(in: CharacterSet.init(charactersIn: "'")) + "'"
         } else {
-            newPath = prefixPath + "/" + pathAppendix!
+            newPath = prefixPath + "/" + pathAppendix
         }
+
         addressStorage.add(address: newAddress, for: newPath)
         guard let serializedRootNode = rootNode.serialize(serializePublic: false) else {throw AbstractKeystoreError.keyDerivationError}
-        try encryptDataToStorage(password, data: serializedRootNode, aesMode: self.keystoreParams!.crypto.cipher)
+        try encryptDataToStorage(password, data: serializedRootNode, aesMode: keystoreParams.crypto.cipher)
     }
 
     /// Fast generation addresses for current account
-    /// used for shows which address user will get when changed number of his wallet
+    /// used to show which addresses the user can get for indices from `0` to `number-1`
     /// - Parameters:
     ///   - password: password of seed storage
-    ///   - number: number of wallets addresses needed to generate from 0 to number-1
-    /// - Returns: Array of addresses generated from 0 to number bound, or empty array in case of error
-    public func getAddressForAccount(password: String, number: Int) -> [EthereumAddress] {
-        guard let decryptedRootNode = try? getPrefixNodeData(password) else {
-            return []
+    ///   - number: number of wallets addresses needed to generate from  `0` to `number-1`
+    /// - Returns: Array of addresses generated from `0` to number bound
+    public func getAddressForAccount(password: String, number: UInt) throws -> [EthereumAddress] {
+        guard let decryptedRootNode = try? getPrefixNodeData(password),
+              let rootNode = HDNode(decryptedRootNode) else {
+            throw AbstractKeystoreError.encryptionError("Failed to decrypt a keystore")
         }
-        guard let rootNode = HDNode(decryptedRootNode) else {
-            return []
-        }
-        let prefixPath = self.rootPrefix
 
-        return [Int](0..<number).compactMap { number in
-            var pathAppendix: String?
-            let path = prefixPath + "/\(number)"
-            if path.hasPrefix(prefixPath) {
-                let upperIndex = (path.range(of: prefixPath)?.upperBound)!
-                if upperIndex < path.endIndex {
-                    pathAppendix = String(path[path.index(after: upperIndex)..<path.endIndex])
-                } else {
-                    return nil
-                }
-
-                guard pathAppendix != nil else {
-                    return nil
-                }
-                if pathAppendix!.hasPrefix("/") {
-                    pathAppendix = pathAppendix?.trimmingCharacters(in: CharacterSet.init(charactersIn: "/"))
-                }
-            } else {
-                if path.hasPrefix("/") {
-                    pathAppendix = path.trimmingCharacters(in: CharacterSet.init(charactersIn: "/"))
-                }
+        return try [UInt](0..<number).compactMap({ number in
+            guard rootNode.depth == rootPrefix.components(separatedBy: "/").count - 1,
+                  let newNode = rootNode.derive(path: "\(number)", derivePrivateKey: true) else {
+                throw AbstractKeystoreError.keyDerivationError
             }
-            guard pathAppendix != nil,
-                  rootNode.depth == prefixPath.components(separatedBy: "/").count - 1,
-                  let newNode = rootNode.derive(path: pathAppendix!, derivePrivateKey: true),
-                  let newAddress = Utilities.publicToAddress(newNode.publicKey) else {
-                return nil
-            }
-            return newAddress
-        }
+            return Utilities.publicToAddress(newNode.publicKey)
+        })
     }
 
     fileprivate func encryptDataToStorage(_ password: String, data: Data, dkLen: Int = 32, N: Int = 4096, R: Int = 6, P: Int = 1, aesMode: String = "aes-128-cbc") throws {

--- a/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
@@ -217,13 +217,13 @@ public class BIP32Keystore: AbstractKeystore {
               let rootNode = HDNode(decryptedRootNode) else {
             throw AbstractKeystoreError.encryptionError("Failed to decrypt a keystore")
         }
-        return try [UInt](0..<number).compactMap({ number in
+        return try [UInt](0..<number).compactMap() { number in
             guard rootNode.depth == rootPrefix.components(separatedBy: "/").count - 1,
                   let newNode = rootNode.derive(path: "\(number)", derivePrivateKey: true) else {
                 throw AbstractKeystoreError.keyDerivationError
             }
             return Utilities.publicToAddress(newNode.publicKey)
-        })
+        }
     }
 
     fileprivate func encryptDataToStorage(_ password: String, data: Data, dkLen: Int = 32, N: Int = 4096, R: Int = 6, P: Int = 1, aesMode: String = "aes-128-cbc") throws {

--- a/Tests/web3swiftTests/localTests/BIP32KeystoreTests.swift
+++ b/Tests/web3swiftTests/localTests/BIP32KeystoreTests.swift
@@ -13,6 +13,7 @@ import Web3Core
 
 class BIP32KeystoreTests: XCTestCase {
     func testAddressGeneration() throws {
+        /// Arrange
         /// Seed randomly generated for this test
         let mnemonic = "resource beyond merit enemy foot piece reveal eagle nothing luggage goose spot"
         let password = "test_password"
@@ -29,10 +30,9 @@ class BIP32KeystoreTests: XCTestCase {
             throw NSError(domain: "0", code: 0)
         }
 
+        /// Act
         let addresses = try keystore.getAddressForAccount(password: password,
                                                           number: addressesCount)
-        XCTAssertEqual(UInt(addresses.count), addressesCount)
-        XCTAssertNotEqual(addresses[11], addresses[1])
 
         guard let sameKeystore = try BIP32Keystore(
             mnemonics: mnemonic,
@@ -48,6 +48,15 @@ class BIP32KeystoreTests: XCTestCase {
         try sameKeystore.createNewCustomChildAccount(password: password,
                                                      path: HDNode.defaultPathMetamaskPrefix + "/\(walletNumber)")
         let address = sameKeystore.addresses?.last?.address
+
+        /// Assert
+        XCTAssertEqual(UInt(addresses.count), addressesCount)
+        XCTAssertNotEqual(addresses[11], addresses[1])
         XCTAssertEqual(addresses.last?.address, address)
+        XCTAssertEqual("0xEF22ebb8Bb5CDa4EaCc98b280c94Cbaa3828566F", addresses.last?.address)
+        XCTAssertEqual("0xdc69CBFE39c46B104875DF9602dFdCDB9b862a16", addresses.first?.address)
+        XCTAssertEqual("0xdc69CBFE39c46B104875DF9602dFdCDB9b862a16", sameKeystore.addresses?.first?.address)
+        XCTAssertEqual("0x971CF293b46162CD03DD9Cc39E89B592988DD6C4", addresses[Int(addressesCount / 2)].address)
+        XCTAssertEqual("0x3B565482a93CE4adA9dE0fD3c118bd41E24CC23C", addresses[10].address)
     }
 }

--- a/Tests/web3swiftTests/localTests/BIP32KeystoreTests.swift
+++ b/Tests/web3swiftTests/localTests/BIP32KeystoreTests.swift
@@ -1,0 +1,54 @@
+//
+//  BIP32KeystoreTests.swift
+//  localTests
+//
+//  Created by 6od9i on 29.06.2023.
+//
+
+import Foundation
+import XCTest
+import Web3Core
+
+@testable import web3swift
+
+class BIP32KeystoreTests: XCTestCase {
+    func testAddressGeneration() throws {
+        /// Seed randomly generated for this test
+        let mnemonic = "resource beyond merit enemy foot piece reveal eagle nothing luggage goose spot"
+        let password = "test_password"
+        
+        let addressesCount = 101
+        
+        guard let keystore = try BIP32Keystore(
+            mnemonics: mnemonic,
+            password: password,
+            mnemonicsPassword: "",
+            language: .english,
+            prefixPath: HDNode.defaultPathMetamaskPrefix) else {
+            XCTFail("Keystore has not generated")
+            throw NSError(domain: "0", code: 0)
+        }
+        
+        let addresses = keystore.getAddressForAccount(password: password,
+                                                      preffixPath: HDNode.defaultPathMetamaskPrefix,
+                                                      number: addressesCount)
+        XCTAssertEqual(addresses.count, addressesCount)
+        XCTAssertNotEqual(addresses[11], addresses[1])
+        
+        guard let sameKeystore = try BIP32Keystore(
+            mnemonics: mnemonic,
+            password: password,
+            mnemonicsPassword: "",
+            language: .english,
+            prefixPath: HDNode.defaultPathMetamaskPrefix) else {
+            XCTFail("Keystore has not generated")
+            throw NSError(domain: "0", code: 0)
+        }
+        
+        let walletNumber = addressesCount - 1
+        try sameKeystore.createNewCustomChildAccount(password: password,
+                                                     path: HDNode.defaultPathMetamaskPrefix + "/\(walletNumber)")
+        let address = sameKeystore.addresses?.last?.address
+        XCTAssertEqual(addresses.last?.address, address)
+    }
+}

--- a/Tests/web3swiftTests/localTests/BIP32KeystoreTests.swift
+++ b/Tests/web3swiftTests/localTests/BIP32KeystoreTests.swift
@@ -30,7 +30,6 @@ class BIP32KeystoreTests: XCTestCase {
         }
         
         let addresses = keystore.getAddressForAccount(password: password,
-                                                      preffixPath: HDNode.defaultPathMetamaskPrefix,
                                                       number: addressesCount)
         XCTAssertEqual(addresses.count, addressesCount)
         XCTAssertNotEqual(addresses[11], addresses[1])

--- a/Tests/web3swiftTests/localTests/BIP32KeystoreTests.swift
+++ b/Tests/web3swiftTests/localTests/BIP32KeystoreTests.swift
@@ -17,7 +17,7 @@ class BIP32KeystoreTests: XCTestCase {
         let mnemonic = "resource beyond merit enemy foot piece reveal eagle nothing luggage goose spot"
         let password = "test_password"
         
-        let addressesCount = 101
+        let addressesCount: UInt = 101
         
         guard let keystore = try BIP32Keystore(
             mnemonics: mnemonic,
@@ -29,9 +29,9 @@ class BIP32KeystoreTests: XCTestCase {
             throw NSError(domain: "0", code: 0)
         }
         
-        let addresses = keystore.getAddressForAccount(password: password,
-                                                      number: addressesCount)
-        XCTAssertEqual(addresses.count, addressesCount)
+        let addresses = try keystore.getAddressForAccount(password: password,
+                                                          number: addressesCount)
+        XCTAssertEqual(UInt(addresses.count), addressesCount)
         XCTAssertNotEqual(addresses[11], addresses[1])
         
         guard let sameKeystore = try BIP32Keystore(

--- a/Tests/web3swiftTests/localTests/BIP32KeystoreTests.swift
+++ b/Tests/web3swiftTests/localTests/BIP32KeystoreTests.swift
@@ -16,9 +16,9 @@ class BIP32KeystoreTests: XCTestCase {
         /// Seed randomly generated for this test
         let mnemonic = "resource beyond merit enemy foot piece reveal eagle nothing luggage goose spot"
         let password = "test_password"
-        
+
         let addressesCount: UInt = 101
-        
+
         guard let keystore = try BIP32Keystore(
             mnemonics: mnemonic,
             password: password,
@@ -28,12 +28,12 @@ class BIP32KeystoreTests: XCTestCase {
             XCTFail("Keystore has not generated")
             throw NSError(domain: "0", code: 0)
         }
-        
+
         let addresses = try keystore.getAddressForAccount(password: password,
                                                           number: addressesCount)
         XCTAssertEqual(UInt(addresses.count), addressesCount)
         XCTAssertNotEqual(addresses[11], addresses[1])
-        
+
         guard let sameKeystore = try BIP32Keystore(
             mnemonics: mnemonic,
             password: password,
@@ -43,7 +43,7 @@ class BIP32KeystoreTests: XCTestCase {
             XCTFail("Keystore has not generated")
             throw NSError(domain: "0", code: 0)
         }
-        
+
         let walletNumber = addressesCount - 1
         try sameKeystore.createNewCustomChildAccount(password: password,
                                                      path: HDNode.defaultPathMetamaskPrefix + "/\(walletNumber)")


### PR DESCRIPTION
- Generation amount of addresses added
- Generation wallet with index > 9 FIXED
- Test generation addresses added


I had added method for faster generation addresses by derivation path index in seed, and found bug with generation.

There was bug with generation wallets from seed when index has more than 1 symbol, for example:
 address of wallet  "m/44'/60'/0'/1" same with wallet "m/44'/60'/0'/10" or "m/44'/60'/0'/121"