### PR TITLE
Feat/decode error

### DIFF
--- a/Sources/Web3Core/Contract/ContractProtocol.swift
+++ b/Sources/Web3Core/Contract/ContractProtocol.swift
@@ -144,7 +144,8 @@ public protocol ContractProtocol {
     ///     - method signature (with or without `0x` prefix, case insensitive): `0xFFffFFff`;
     ///   - data: non empty bytes to decode;
     /// - Returns: dictionary with decoded values. `nil` if decoding failed.
-    func decodeReturnData(_ method: String, data: Data) -> [String: Any]?
+    @discardableResult
+    func decodeReturnData(_ method: String, data: Data) throws -> [String: Any]
 
     /// Decode input arguments of a function.
     /// - Parameters:
@@ -313,13 +314,40 @@ extension DefaultContractProtocol {
         return bloom.test(topic: event.topic)
     }
 
-    public func decodeReturnData(_ method: String, data: Data) -> [String: Any]? {
+    @discardableResult
+    public func decodeReturnData(_ method: String, data: Data) throws -> [String: Any] {
         if method == "fallback" {
-            return [String: Any]()
+            return [:]
         }
-        return methods[method]?.compactMap({ function in
-            return function.decodeReturnData(data)
-        }).first
+
+        guard let function = methods[method]?.first else {
+            throw Web3Error.inputError(desc: "Function method does not exist.")
+        }
+
+        switch data.count % 32 {
+        case 0:
+            return try function.decodeReturnData(data)
+        case 4:
+            let selector = data[0..<4]
+            if selector.toHexString() == "08c379a0", let reason = ABI.Element.EthError.decodeStringError(data[4...]) {
+                throw Web3Error.revert("revert(string)` or `require(expression, string)` was executed. reason: \(reason)", reason: reason)
+            }
+            else if selector.toHexString() == "4e487b71", let reason = ABI.Element.EthError.decodePanicError(data[4...]) {
+                let panicCode = String(format: "%02X", Int(reason)).addHexPrefix()
+                throw Web3Error.revert("Error: call revert exception; VM Exception while processing transaction: reverted with panic code \(panicCode)", reason: panicCode)
+            }
+            else if let customError = errors[selector.toHexString().addHexPrefix().lowercased()] {
+                if let errorArgs = customError.decodeEthError(data[4...]) {
+                    throw Web3Error.revertCustom(customError.signature, errorArgs)
+                } else {
+                    throw Web3Error.inputError(desc: "Signature matches \(customError.errorDeclaration) but failed to be decoded.")
+                }
+            } else {
+                throw Web3Error.inputError(desc: "Found no matched error")
+            }
+        default:
+            throw Web3Error.inputError(desc: "Invalid data count")
+        }
     }
 
     public func decodeInputData(_ method: String, data: Data) -> [String: Any]? {
@@ -339,8 +367,32 @@ extension DefaultContractProtocol {
         return function.decodeInputData(Data(data[data.startIndex + 4 ..< data.startIndex + data.count]))
     }
 
+    public func decodeEthError(_ data: Data) -> [String: Any]? {
+        guard data.count >= 4,
+              let err = errors.first(where: { $0.value.methodEncoding == data[0..<4] })?.value else {
+            return nil
+        }
+        return err.decodeEthError(data[4...])
+    }
+
     public func getFunctionCalled(_ data: Data) -> ABI.Element.Function? {
         guard data.count >= 4 else { return nil }
         return methods[data[data.startIndex ..< data.startIndex + 4].toHexString().addHexPrefix()]?.first
+    }
+}
+
+extension DefaultContractProtocol {
+    @discardableResult
+    public func callStatic(_ method: String, parameters: [Any], provider: Web3Provider) async throws -> [String: Any] {
+        guard let address = address else {
+            throw Web3Error.inputError(desc: "address field is missing")
+        }
+        guard let data = self.method(method, parameters: parameters, extraData: nil) else {
+            throw Web3Error.dataError
+        }
+        let transaction = CodableTransaction(to: address, data: data)
+
+        let result: Data = try await APIRequest.sendRequest(with: provider, for: .call(transaction, .latest)).result
+        return try decodeReturnData(method, data: result)
     }
 }

--- a/Sources/Web3Core/EthereumABI/ABIParameterTypes.swift
+++ b/Sources/Web3Core/EthereumABI/ABIParameterTypes.swift
@@ -192,6 +192,20 @@ extension ABI.Element.Event {
     }
 }
 
+extension ABI.Element.EthError {
+    public var signature: String {
+        return "\(name)(\(inputs.map { $0.type.abiRepresentation }.joined(separator: ",")))"
+    }
+
+    public var methodString: String {
+        return String(signature.sha3(.keccak256).prefix(8))
+    }
+
+    public var methodEncoding: Data {
+        return signature.data(using: .ascii)!.sha3(.keccak256)[0...3]
+    }
+}
+
 extension ABI.Element.ParameterType: ABIEncoding {
     public var abiRepresentation: String {
         switch self {

--- a/Sources/Web3Core/EthereumABI/Sequence+ABIExtension.swift
+++ b/Sources/Web3Core/EthereumABI/Sequence+ABIExtension.swift
@@ -56,6 +56,8 @@ public extension Sequence where Element == ABI.Element {
         var errors = [String: ABI.Element.EthError]()
         for case let .error(error) in self {
             errors[error.name] = error
+            errors[error.signature] = error
+            errors[error.methodString.addHexPrefix().lowercased()] = error
         }
         return errors
     }

--- a/Sources/Web3Core/EthereumNetwork/Request/APIRequest+ComputedProperties.swift
+++ b/Sources/Web3Core/EthereumNetwork/Request/APIRequest+ComputedProperties.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension APIRequest {
-    var method: REST {
+    public var method: REST {
          .POST
     }
 

--- a/Sources/Web3Core/EthereumNetwork/Request/APIRequest+ComputedProperties.swift
+++ b/Sources/Web3Core/EthereumNetwork/Request/APIRequest+ComputedProperties.swift
@@ -12,11 +12,8 @@ extension APIRequest {
          .POST
     }
 
-   public var encodedBody: Data {
-        let request = RequestBody(method: call, params: parameters)
-        // this is safe to force try this here
-        // Because request must failed to compile if it not conformable with `Encodable` protocol
-        return try! JSONEncoder().encode(request)
+    public var encodedBody: Data {
+       RequestBody(method: call, params: parameters).encodedBody
     }
 
     var parameters: [RequestParameter] {

--- a/Sources/Web3Core/EthereumNetwork/Request/APIRequest+Methods.swift
+++ b/Sources/Web3Core/EthereumNetwork/Request/APIRequest+Methods.swift
@@ -34,8 +34,12 @@ func spelunkData(value: Any?) -> (message: String, data: String)? {
         return nil
     }
 
-    if let error = value as? JsonRpcErrorObject.RpcError, let data = error.data as? String {
-        return spelunkRpcError(error.message, data: data)
+    if let error = value as? JsonRpcErrorObject.RpcError {
+        if let data = error.data as? String {
+            return spelunkRpcError(error.message, data: data)
+        } else {
+            return spelunkData(value: error.data)
+        }
     }
 
     // Spelunk further...

--- a/Sources/Web3Core/EthereumNetwork/Request/APIRequest+Methods.swift
+++ b/Sources/Web3Core/EthereumNetwork/Request/APIRequest+Methods.swift
@@ -8,45 +8,97 @@
 import Foundation
 import BigInt
 
-extension APIRequest {
-    public static func sendRequest<Result>(with provider: Web3Provider, for call: APIRequest) async throws -> APIResponse<Result> {
-        let request = setupRequest(for: call, with: provider)
-        return try await APIRequest.send(uRLRequest: request, with: provider.session)
+/// TODO: should we do more error explain like ethers.js?
+/// https://github.com/ethers-io/ethers.js/blob/0bfa7f497dc5793b66df7adfb42c6b846c51d794/packages/providers/src.ts/json-rpc-provider.ts#L55
+func checkError(method: String, error: JsonRpcErrorObject.RpcError) throws -> String {
+    if method == "eth_call" {
+        if let result = spelunkData(value: error) {
+            return result.data
+        }
+        throw Web3Error.nodeError(desc: "missing revert data in call exception; Transaction reverted without a reason string")
     }
 
-    static func setupRequest(for call: APIRequest, with provider: Web3Provider) -> URLRequest {
+    throw Web3Error.nodeError(desc: error.message)
+}
+
+func spelunkData(value: Any?) -> (message: String, data: String)? {
+    func spelunkRpcError(_ message: String, data: String) -> (message: String, data: String)? {
+        if message.contains("revert") && data.isHex {
+            return (message, data)
+        } else {
+            return nil
+        }
+    }
+
+    if (value == nil) {
+        return nil
+    }
+
+    if let error = value as? JsonRpcErrorObject.RpcError, let data = error.data as? String {
+        return spelunkRpcError(error.message, data: data)
+    }
+
+    // Spelunk further...
+    if let object = value as? [String: Any] {
+        if let message = object["message"] as? String,
+           let data = object["data"] as? String {
+            return spelunkRpcError(message, data: data)
+        }
+
+        for value in object.values {
+            if let result = spelunkData(value: value) {
+                return result
+            }
+            return nil
+        }
+    }
+    if let array = value as? [Any] {
+        for e in array {
+            if let result = spelunkData(value: e) {
+                return result
+            }
+            return nil
+        }
+    }
+
+    // Might be a JSON string we can further descend...
+    if let string = value as? String, let data = string.data(using: .utf8) {
+        let json = try? JSONSerialization.jsonObject(with: data)
+        return spelunkData(value: json)
+    }
+
+    return nil
+}
+
+extension APIRequest {
+    public static func sendRequest<Result>(with provider: Web3Provider, for call: APIRequest) async throws -> APIResponse<Result> {
+        try await send(call.method.rawValue, parameter: call.parameters, with: provider)
+    }
+
+    static func setupRequest(for body: RequestBody, with provider: Web3Provider) -> URLRequest {
         var urlRequest = URLRequest(url: provider.url, cachePolicy: .reloadIgnoringCacheData)
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-        urlRequest.httpMethod = call.method.rawValue
-        urlRequest.httpBody = call.encodedBody
+        urlRequest.httpMethod = "POST"
+        urlRequest.httpBody = body.encodedBody
         return urlRequest
     }
 
-    public static func send<Result>(uRLRequest: URLRequest, with session: URLSession) async throws -> APIResponse<Result> {
-        let (data, response) = try await session.data(for: uRLRequest)
+    public static func send<Result>(_ method: String, parameter: [Encodable], with provider: Web3Provider) async throws -> APIResponse<Result> {
+        let body = RequestBody(method: method, params: parameter)
+        let uRLRequest = setupRequest(for: body, with: provider)
 
-        guard 200 ..< 400 ~= response.statusCode else {
-            if 400 ..< 500 ~= response.statusCode {
-                throw Web3Error.clientError(code: response.statusCode)
-            } else {
-                throw Web3Error.serverError(code: response.statusCode)
+        let data: Data
+        do {
+            data = try await send(uRLRequest: uRLRequest, with: provider.session)
+        } catch Web3Error.rpcError(let error) {
+            let responseAsString = try checkError(method: method, error: error)
+            guard let LiteralType = Result.self as? LiteralInitiableFromString.Type,
+                  let literalValue = LiteralType.init(from: responseAsString),
+                  let result = literalValue as? Result else {
+                throw Web3Error.dataError
             }
-        }
-
-        if let error = (try? JSONDecoder().decode(JsonRpcErrorObject.self, from: data))?.error {
-            guard let parsedErrorCode = error.parsedErrorCode else {
-                throw Web3Error.nodeError(desc: "\(error.message)\nError code: \(error.code)")
-            }
-            let description = "\(parsedErrorCode.errorName). Error code: \(error.code). \(error.message)"
-            switch parsedErrorCode {
-            case .parseError, .invalidParams:
-                throw Web3Error.inputError(desc: description)
-            case .methodNotFound, .invalidRequest:
-                throw Web3Error.processingError(desc: description)
-            case .internalError, .serverError:
-                throw Web3Error.nodeError(desc: description)
-            }
+            return APIResponse(id: 2, result: result)
         }
 
         /// This bit of code is purposed to work with literal types that comes in ``Response`` in hexString type.
@@ -60,24 +112,78 @@ extension APIRequest {
         }
         return try JSONDecoder().decode(APIResponse<Result>.self, from: data)
     }
+
+    public static func send(uRLRequest: URLRequest, with session: URLSession) async throws -> Data {
+        let (data, response) = try await session.data(for: uRLRequest)
+
+        guard 200 ..< 400 ~= response.statusCode else {
+            if 400 ..< 500 ~= response.statusCode {
+                throw Web3Error.clientError(code: response.statusCode)
+            } else {
+                throw Web3Error.serverError(code: response.statusCode)
+            }
+        }
+
+        if let error = JsonRpcErrorObject.init(from: data)?.error {
+            guard let parsedErrorCode = error.parsedErrorCode else {
+                throw Web3Error.rpcError(error)
+            }
+            let description = "\(parsedErrorCode.errorName). Error code: \(error.code). \(error.message)"
+            switch parsedErrorCode {
+            case .parseError, .invalidParams:
+                throw Web3Error.inputError(desc: description)
+            case .methodNotFound, .invalidRequest:
+                throw Web3Error.processingError(desc: description)
+            case .internalError, .serverError:
+                throw Web3Error.nodeError(desc: description)
+            }
+        }
+
+        return data
+    }
 }
 
 /// JSON RPC Error object. See official specification https://www.jsonrpc.org/specification#error_object
-private struct JsonRpcErrorObject: Decodable {
+public struct JsonRpcErrorObject {
     public let error: RpcError?
 
-    class RpcError: Decodable {
-        let message: String
-        let code: Int
+    public class RpcError {
+        public let message: String
+        public let code: Int
+        public let data: Any?
+
+        init(message: String, code: Int, data: Any?) {
+            self.message = message
+            self.code = code
+            self.data = data
+        }
+
         var parsedErrorCode: JsonRpcErrorCode? {
             JsonRpcErrorCode.from(code)
+        }
+    }
+
+    init?(from data: Data) {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        if let error = root["error"] as? [String: Any],
+           let message = error["message"] as? String,
+           let code = error["code"] as? Int {
+            guard let errorData = error["data"] else {
+                self.error = RpcError(message: message, code: code, data: nil)
+                return
+            }
+            self.error = RpcError(message: message, code: code, data: errorData)
+        } else {
+            self.error = nil
         }
     }
 }
 
 /// For error codes specification see chapter `5.1 Error object`
 /// https://www.jsonrpc.org/specification#error_object
-private enum JsonRpcErrorCode {
+enum JsonRpcErrorCode {
     /// -32700
     /// Invalid JSON was received by the server. An error occurred on the server while parsing the JSON
     case parseError

--- a/Sources/Web3Core/EthereumNetwork/Request/APIRequest+UtilityTypes.swift
+++ b/Sources/Web3Core/EthereumNetwork/Request/APIRequest+UtilityTypes.swift
@@ -14,7 +14,7 @@ public struct APIResponse<Result>: Decodable where Result: APIResultType {
     public var result: Result
 }
 
-enum REST: String {
+public enum REST: String {
     case POST
     case GET
 }

--- a/Sources/Web3Core/EthereumNetwork/Request/APIRequest+UtilityTypes.swift
+++ b/Sources/Web3Core/EthereumNetwork/Request/APIRequest+UtilityTypes.swift
@@ -24,5 +24,30 @@ struct RequestBody: Encodable {
     var id = Counter.increment()
 
     var method: String
-    var params: [RequestParameter]
+    var params: [Encodable]
+
+    enum CodingKeys: String, CodingKey {
+        case jsonrpc
+        case id
+        case method
+        case params
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(jsonrpc, forKey: .jsonrpc)
+        try container.encode(id, forKey: .id)
+        try container.encode(method, forKey: .method)
+
+        var paramsContainer = container.superEncoder(forKey: .params).unkeyedContainer()
+        try params.forEach { a in
+            try paramsContainer.encode(a)
+        }
+    }
+
+    public var encodedBody: Data {
+         // this is safe to force try this here
+         // Because request must failed to compile if it not conformable with `Encodable` protocol
+         return try! JSONEncoder().encode(self)
+     }
 }

--- a/Sources/Web3Core/Utility/String+Extension.swift
+++ b/Sources/Web3Core/Utility/String+Extension.swift
@@ -135,6 +135,10 @@ extension String {
     func trim() -> String {
         trimmingCharacters(in: .whitespacesAndNewlines)
     }
+
+    public var isHex: Bool {
+        stripHexPrefix().reduce(true, { $0 && $1.isHexDigit } )
+    }
 }
 
 extension Character {

--- a/Sources/Web3Core/Web3Error/Web3Error.swift
+++ b/Sources/Web3Core/Web3Error/Web3Error.swift
@@ -25,6 +25,11 @@ public enum Web3Error: LocalizedError {
     case generalError(err: Error)
     case unknownError
 
+    case rpcError(JsonRpcErrorObject.RpcError)
+    case revert(String, reason: String?)
+    case revertCustom(String, [String: Any])
+
+
     public var errorDescription: String? {
         switch self {
         case .transactionSerializationError:
@@ -55,6 +60,12 @@ public enum Web3Error: LocalizedError {
             return "Client error: \(code)"
         case .valueError(let errorDescription):
             return (errorDescription?.isEmpty ?? true) ? "You're passing value that isn't supported by this method" : errorDescription!
+        case .rpcError(let error):
+            return error.message
+        case .revert(let message, let reason):
+            return "\(message); reverted with reason string: \(reason ?? "")"
+        case .revertCustom(let error, _):
+            return "reverted with custom error: \(error)"
         }
     }
 }

--- a/Sources/web3swift/Operations/ReadOperation.swift
+++ b/Sources/web3swift/Operations/ReadOperation.swift
@@ -43,9 +43,6 @@ public class ReadOperation {
             let resultHex = data.toHexString().addHexPrefix()
             return ["result": resultHex]
         }
-        guard let decodedData = self.contract.decodeReturnData(self.method, data: data) else {
-            throw Web3Error.processingError(desc: "Can not decode returned parameters")
-        }
-        return decodedData
+        return try self.contract.decodeReturnData(self.method, data: data)
     }
 }

--- a/Sources/web3swift/Web3/Web3+Contract.swift
+++ b/Sources/web3swift/Web3/Web3+Contract.swift
@@ -112,5 +112,11 @@ extension Web3 {
             }
             return .init(transaction: transaction, web3: web3, contract: contract, method: method)
         }
+
+        /// Combines `createReadOperation`& `callContractMethod`
+        @discardableResult
+        public func callStatic(_ method: String, parameters: [Any]) async throws -> [String: Any] {
+            try await contract.callStatic(method, parameters: parameters, provider: web3.provider)
+        }
     }
 }

--- a/Sources/web3swift/Web3/Web3+HttpProvider.swift
+++ b/Sources/web3swift/Web3/Web3+HttpProvider.swift
@@ -36,7 +36,7 @@ public class Web3HttpProvider: Web3Provider {
             var urlRequest = URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData)
             urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
             urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-            urlRequest.httpMethod = APIRequest.getNetwork.call
+            urlRequest.httpMethod = APIRequest.getNetwork.method.rawValue
             urlRequest.httpBody = APIRequest.getNetwork.encodedBody
             let response: APIResponse<UInt> = try await APIRequest.send(uRLRequest: urlRequest, with: session)
             self.network = Networks.fromInt(response.result)

--- a/Sources/web3swift/Web3/Web3+HttpProvider.swift
+++ b/Sources/web3swift/Web3/Web3+HttpProvider.swift
@@ -33,13 +33,8 @@ public class Web3HttpProvider: Web3Provider {
         if let net = net {
             network = net
         } else {
-            var urlRequest = URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData)
-            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-            urlRequest.httpMethod = APIRequest.getNetwork.method.rawValue
-            urlRequest.httpBody = APIRequest.getNetwork.encodedBody
-            let response: APIResponse<UInt> = try await APIRequest.send(uRLRequest: urlRequest, with: session)
-            self.network = Networks.fromInt(response.result)
+            let response: UInt = try await APIRequest.send(APIRequest.getNetwork.call, parameter: [], with: self).result
+            self.network = Networks.fromInt(response)
         }
         attachedKeystoreManager = manager
     }

--- a/Tests/web3swiftTests/localTests/ABIDecoderSliceTests.swift
+++ b/Tests/web3swiftTests/localTests/ABIDecoderSliceTests.swift
@@ -27,7 +27,7 @@ final class ABIDecoderSliceTests: XCTestCase {
         while startIndex < data.count {
             let slice = data[startIndex ..< startIndex + answerSize]
             startIndex += answerSize
-            guard let bigInt = balanceofMethod.decodeReturnData(slice)["0"] as? BigUInt else {
+            guard let bigInt = try balanceofMethod.decodeReturnData(slice)["0"] as? BigUInt else {
                 throw Web3Error.processingError(desc: "Can not decode returned parameters")
             }
             let value = Utilities.formatToPrecision(bigInt, units: .wei)
@@ -52,9 +52,7 @@ final class ABIDecoderSliceTests: XCTestCase {
         XCTAssertEqual(methods.count, 3)
 
         /// Act
-        guard let decodedData = multiCall2Contract.decodeReturnData("aggregate", data: data) else {
-            throw Web3Error.processingError(desc: "Can not decode returned parameters")
-        }
+        let decodedData = try multiCall2Contract.decodeReturnData("aggregate", data: data)
 
         guard let returnData = decodedData["returnData"] as? [Data] else {
             throw Web3Error.dataError
@@ -63,7 +61,7 @@ final class ABIDecoderSliceTests: XCTestCase {
         XCTAssertEqual(returnData.count, 3)
 
         for item in methods.enumerated() {
-            XCTAssertNotNil(item.element.decodeReturnData(returnData[item.offset])["0"])
+            XCTAssertNotNil(try item.element.decodeReturnData(returnData[item.offset])["0"])
         }
     }
 
@@ -74,9 +72,7 @@ final class ABIDecoderSliceTests: XCTestCase {
         let erc20_balanceof = try EthereumContract(Web3.Utils.erc20ABI).methods["balanceOf"]!.first!
 
         /// Act
-        guard let decodedData = contract.decodeReturnData("tryAggregate", data: data) else {
-            throw Web3Error.processingError(desc: "Can not decode returned parameters")
-        }
+        let decodedData = try contract.decodeReturnData("tryAggregate", data: data)
 
         guard let returnData = decodedData["returnData"] as? [[Any]] else {
             throw Web3Error.dataError
@@ -84,7 +80,7 @@ final class ABIDecoderSliceTests: XCTestCase {
         var resultArray = [BigUInt]()
         for i in 0..<2 {
             guard let data = returnData[i][1] as? Data,
-                  let balance = erc20_balanceof.decodeReturnData(data)["0"] as? BigUInt else {
+                  let balance = try? erc20_balanceof.decodeReturnData(data)["0"] as? BigUInt else {
                 resultArray.append(0)
                 continue
             }

--- a/Tests/web3swiftTests/localTests/UtilitiesTests.swift
+++ b/Tests/web3swiftTests/localTests/UtilitiesTests.swift
@@ -82,4 +82,9 @@ class UtilitiesTests: XCTestCase {
         address = Utilities.publicToAddress(Data.fromHex("0x0852972572d465d016d4c501887b8df303eee3ed602c056b1eb09260dfa0da0ab2")!)?.address
         XCTAssertEqual(address, nil)
     }
+
+    func testStringIsHex() {
+        XCTAssertTrue("1234567890abcdef".isHex)
+        XCTAssertFalse("ghijklmn".isHex)
+    }
 }

--- a/Tests/web3swiftTests/remoteTests/DecodeRemoteErrorTests.swift
+++ b/Tests/web3swiftTests/remoteTests/DecodeRemoteErrorTests.swift
@@ -1,0 +1,53 @@
+//
+//  DecodeRemoteErrorTests.swift
+//
+//  Created by liugang zhang on 2023/8/25.
+//
+
+import XCTest
+import Web3Core
+
+@testable import web3swift
+
+final class DecodeRemoteErrorTests: XCTestCase {
+
+    let entryPoint = EthereumAddress("0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789")!
+    let factory = EthereumAddress("0x9406Cc6185a346906296840746125a0E44976454")!
+    let address = EthereumAddress("0x581074D2d9e50913eB37665b07CAFa9bFFdd1640")!
+
+    func testDecodeRemoteFunc() async throws {
+        let web3 = try await Web3.InfuraMainnetWeb3(accessToken: Constants.infuraToken)
+        
+        let entryABI = try EthereumContract(abi: [
+            .error(.init(name: "SenderAddressResult",
+                         inputs: [.init(name: "sender", type: .address)])),
+            .function(.init(name: "getSenderAddress",
+                            inputs: [.init(name: "initCode", type: .dynamicBytes)],
+                            outputs: [],
+                            constant: false,
+                            payable: false))
+        ], at: entryPoint)
+
+        let factoryABI = try EthereumContract(abi: [
+            .function(.init(name: "createAccount",
+                            inputs: [
+                                .init(name: "owner", type: .address),
+                                .init(name: "salt", type: .uint(bits: 256))
+                            ],
+                            outputs: [],
+                            constant: false,
+                            payable: false))
+        ])
+
+        let initCode = factory.addressData + factoryABI.method("createAccount", parameters: [address, 0], extraData: nil)!
+
+        do {
+            try await entryABI.callStatic("getSenderAddress", parameters: [initCode], provider: web3.provider)
+            XCTFail()
+        } catch Web3Error.revertCustom(let signature, let args) {
+            XCTAssertEqual(signature, "SenderAddressResult(address)")
+            XCTAssertEqual((args["sender"] as? EthereumAddress)?.address, "0x9CF91286f22a1b799770fB5De0E66f3C4cc165d1")
+            XCTAssertEqual((args["0"] as? EthereumAddress)?.address, "0x9CF91286f22a1b799770fB5De0E66f3C4cc165d1")
+        }
+    }
+}

--- a/Tests/web3swiftTests/remoteTests/InfuraTests.swift
+++ b/Tests/web3swiftTests/remoteTests/InfuraTests.swift
@@ -11,6 +11,12 @@ import Web3Core
 // MARK: Works only with network connection
 class InfuraTests: XCTestCase {
 
+    func testGetNetwork() async throws {
+        let requestURLstring = "https://" + Networks.Mainnet.name + Constants.infuraHttpScheme + Constants.infuraToken
+        let web3 = try await Web3HttpProvider(url: URL(string: requestURLstring)!, network: nil)
+        XCTAssertEqual(web3.network?.chainID, 1)
+    }
+
     func testGetBalance() async throws {
         let web3 = try await Web3.InfuraMainnetWeb3(accessToken: Constants.infuraToken)
         let address = EthereumAddress("0xd61b5ca425F8C8775882d4defefC68A6979DBbce")!


### PR DESCRIPTION
## **Summary of Changes**

### Handle revert exception
When a contract call reverted, we may get different data format of response data from different chains, for example:
```
{
  "jsonrpc": "2.0",
  "id": 1,
  "result": "0x6ca7b806000000000000000000000000581074d2d9e50913eb37665b07cafa9bffdd1640"
}
```

```
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": 3,
    "data": "0x6ca7b8060000000000000000000000009cf91286f22a1b799770fb5de0e66f3c4cc165d1",
    "message": "execution reverted"
  }
}
```
As so far we can only handle the first condition, So in `APIRequest+Method.swift`, I add a new function to handle the second one, and return the `error.data` field as `result`
Seems [ethers.js](https://github.com/ethers-io/ethers.js/blob/0bfa7f497dc5793b66df7adfb42c6b846c51d794/packages/providers/src.ts/json-rpc-provider.ts#L55) has a complex logic about this, I am not sure which chain will return a revert error in more deeper nesting object.

### RequestBody
`RequestBody` now accept any object conforms to `Encodable` as params, maybe we can remove `APIRequestParameterType` safely.

### Break changes
Refactor `ContractProtocol.decodeReturnData(_ method: String, data: Data) -> [String: Any]?`
to `ContractProtocol.decodeReturnData(_ method: String, data: Data) throws -> [String: Any]`

This function will throw `Web3Error.revert(String, reason: String?)` or `Web3Error.revertCustom(String, [String: Any])` when `data` parameter contains an error.
Removed fields with `_` prefix from return Dictionary, it only return fields that decoded from given Function.

This also effects `ReadOperation.callContractMethod`

---

Refactor `ABI.Element.Function.decodeReturnData(_ data: Data, errors: [String: ABI.Element.EthError]? = nil) -> [String: Any]`
to `ABI.Element.Function.decodeReturnData(_ data: Data) throws -> [String: Any]`

Add decode error method to `ABI.Element.EthError`, error decode is moved from `Function` to `EthError`

_many test data in `ABIElementErrorDecodingTest.swfit` has wrong byte length, i have no idea why those tests were passed._

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
