### PR TITLE
#846: change minimum version of CryptoSwift dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.5.1")
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.8.0")
     ],
     targets: [
         .target(name: "secp256k1"),


### PR DESCRIPTION
The minimum version of 1.5.1 is too small. These changes resolve dependency conflicts that have the 'CryptoSwift' dependency within the SPM package, e.g. 'SwiftLint' that uses the 'CryptoSwift' too

## **Summary of Changes**

Fixes # _(if applicable - add the number of issue this PR addresses)_

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
