### PR TITLE
fix: BIP39 use given language to generate mnemonics;

### DIFF
--- a/Sources/Web3Core/KeystoreManager/BIP39.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP39.swift
@@ -6,7 +6,7 @@
 import Foundation
 import CryptoSwift
 
-public enum BIP39Language {
+public enum BIP39Language: CaseIterable {
     case english
     case chinese_simplified
     case chinese_traditional
@@ -124,7 +124,7 @@ public class BIP39 {
     public static func generateMnemonicsFromEntropy(entropy: Data, language: BIP39Language = .english) -> String? {
         guard entropy.count >= 16, entropy.count & 4 == 0 else { return nil }
         let separator = language.separator
-        let wordList = generateMnemonicsFrom(entropy: entropy)
+        let wordList = generateMnemonicsFrom(entropy: entropy, language: language)
         return wordList.joined(separator: separator)
     }
 

--- a/Sources/Web3Core/KeystoreManager/BIP39.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP39.swift
@@ -36,7 +36,12 @@ public enum BIP39Language: CaseIterable {
             return spanishWords
         }
     }
+
     public var separator: String {
+        return String(separatorCharacter)
+    }
+
+    public var separatorCharacter: Character {
         switch self {
         case .japanese:
             return "\u{3000}"

--- a/Tests/web3swiftTests/localTests/BIP39Tests.swift
+++ b/Tests/web3swiftTests/localTests/BIP39Tests.swift
@@ -11,6 +11,22 @@ import XCTest
 
 final class BIP39Tests: XCTestCase {
 
+    func testAllLanguageMnemonics() throws {
+        for language in BIP39Language.allCases {
+            guard let newMnemonics = try BIP39.generateMnemonics(bitsOfEntropy: 128, language: language) else {
+                XCTFail("Failed to generate BIP39 mnemonics phrase")
+                return
+            }
+            let wordsOfNewMnemonic = newMnemonics.split(separator: language.separator).map { String($0) }
+            for word in wordsOfNewMnemonic {
+                guard language.words.contains(word) else {
+                    XCTFail("Given word is not contained in the list of words of selected language available for mnemonics generation: \(word); \(language)")
+                    return
+                }
+            }
+        }
+    }
+
     func testBIP39() throws {
         var entropy = Data.fromHex("00000000000000000000000000000000")!
         var phrase = BIP39.generateMnemonicsFromEntropy(entropy: entropy)

--- a/Tests/web3swiftTests/localTests/BIP39Tests.swift
+++ b/Tests/web3swiftTests/localTests/BIP39Tests.swift
@@ -11,22 +11,6 @@ import XCTest
 
 final class BIP39Tests: XCTestCase {
 
-    func testAllLanguageMnemonics() throws {
-        for language in BIP39Language.allCases {
-            guard let newMnemonics = try BIP39.generateMnemonics(bitsOfEntropy: 128, language: language) else {
-                XCTFail("Failed to generate BIP39 mnemonics phrase")
-                return
-            }
-            let wordsOfNewMnemonic = newMnemonics.split(separator: language.separator).map { String($0) }
-            for word in wordsOfNewMnemonic {
-                guard language.words.contains(word) else {
-                    XCTFail("Given word is not contained in the list of words of selected language available for mnemonics generation: \(word); \(language)")
-                    return
-                }
-            }
-        }
-    }
-
     func testBIP39() throws {
         var entropy = Data.fromHex("00000000000000000000000000000000")!
         var phrase = BIP39.generateMnemonicsFromEntropy(entropy: entropy)
@@ -167,6 +151,7 @@ final class BIP39Tests: XCTestCase {
         XCTAssert(keystore1?.addresses?.first == keystore2?.addresses?.first)
     }
 
+    /// It's expected for the entropy bits count to be [128, 256] and (bits mod 32) must return 0.
     func testWrongBitsOfEntropyMustThrow() throws {
         XCTAssertThrowsError(try BIP39.generateMnemonics(entropy: 127))
         XCTAssertThrowsError(try BIP39.generateMnemonics(entropy: 255))
@@ -182,4 +167,33 @@ final class BIP39Tests: XCTestCase {
         XCTAssertFalse(try BIP39.generateMnemonics(entropy: 256).isEmpty)
     }
 
+    func testBip39CorrectWordsCount() throws {
+        XCTAssertEqual(try BIP39.generateMnemonics(entropy: 128).count, 12)
+        XCTAssertEqual(try BIP39.generateMnemonics(entropy: 160).count, 15)
+        XCTAssertEqual(try BIP39.generateMnemonics(entropy: 192).count, 18)
+        XCTAssertEqual(try BIP39.generateMnemonics(entropy: 224).count, 21)
+        XCTAssertEqual(try BIP39.generateMnemonics(entropy: 256).count, 24)
+    }
+
+    func testAllLanguageMnemonics() throws {
+        for language in BIP39Language.allCases {
+            let mnemonicPhrase = try BIP39.generateMnemonics(entropy: 128, language: language)
+            for word in mnemonicPhrase {
+                guard language.words.contains(word) else {
+                    XCTFail("Given word is not contained in the list of words of selected language available for mnemonics generation: \(word); \(language)")
+                    return
+                }
+            }
+        }
+    }
+
+    func testBip39MnemonicSeparatorUse() throws {
+        for language in BIP39Language.allCases {
+            guard let mnemonicPhrase = try BIP39.generateMnemonics(bitsOfEntropy: 128, language: language) else {
+                XCTFail("Failed to generate BIP39 mnemonics phrase with 128 bits of entropy using language: \(language)")
+                return
+            }
+            XCTAssertEqual(mnemonicPhrase.split(whereSeparator: { $0 == language.separatorCharacter }).count, 12)
+        }
+    }
 }


### PR DESCRIPTION
## **Summary of Changes**

One of the users raised an issue where using a language any but English produces only English BIP39 mnemonics. This PR addresses the issue and adds a test to make sure each language uses the correct words.

Original report: https://discord.com/channels/852230666292559882/855075850771496971/1223929794383839293

## **Test Data or Screenshots**

None.

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
