### PR TITLE
Imported <sys/types.h>

### DIFF
--- a/Sources/secp256k1/scalar_4x64_impl.h
+++ b/Sources/secp256k1/scalar_4x64_impl.h
@@ -3,6 +3,7 @@
  * Distributed under the MIT software license, see the accompanying   *
  * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
  **********************************************************************/
+#include <sys/types.h>
 
 #ifndef SECP256K1_SCALAR_REPR_IMPL_H
 #define SECP256K1_SCALAR_REPR_IMPL_H


### PR DESCRIPTION
## **Summary of Changes**

Addresses an issue where builds initiated from Xcode 16 produced errors because of a missing import.

Fixes # 1 (a header import)

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
