### PR TITLE
chore: fix crash for toChecksum when "String index is out of bounds"

### DIFF
--- a/Sources/Web3Core/EthereumAddress/EthereumAddress.swift
+++ b/Sources/Web3Core/EthereumAddress/EthereumAddress.swift
@@ -63,7 +63,8 @@ public struct EthereumAddress: Equatable {
     /// represented as `ASCII` data. Otherwise, checksummed address is returned with `0x` prefix.
     public static func toChecksumAddress(_ addr: String) -> String? {
         let address = addr.lowercased().stripHexPrefix()
-        guard let hash = address.data(using: .ascii)?.sha3(.keccak256).toHexString().stripHexPrefix() else { return nil }
+        guard address.count == 40,
+              let hash = address.data(using: .ascii)?.sha3(.keccak256).toHexString().stripHexPrefix() else { return nil }
         var ret = "0x"
 
         for (i, char) in address.enumerated() {

--- a/Tests/web3swiftTests/localTests/UncategorizedTests.swift
+++ b/Tests/web3swiftTests/localTests/UncategorizedTests.swift
@@ -35,6 +35,12 @@ class UncategorizedTests: LocalTestCase {
         let output = EthereumAddress.toChecksumAddress(input)
         XCTAssert(output == "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359", "Failed to checksum address")
     }
+    
+    func testErrorAddressChecksumAddress() throws {
+        let input = "ethereum:0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359?chainId=1&action=transfer"
+        let output = EthereumAddress.toChecksumAddress(input)
+        XCTAssert(output == nil, "Failed to checksum address")
+    }
 
     func testChecksumAddressParsing() throws {
         let input = "0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359"


### PR DESCRIPTION
## **Summary of Changes**

Fixes # _(if applicable - add the number of issue this PR addresses)_

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
