### PR TITLE
chore: exclude secp256k1 from codespell

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
 count = True
 ignore-words-list = ans,deriver,inout,packag
-skip = *.js,*WordLists.swift,.git,Carthage,.build,build
+skip = *.js,*WordLists.swift,.git,Carthage,.build,build,Sources/secp256k1


### PR DESCRIPTION
## **Summary of Changes**

Current CI fails with codespell checks in secp256k1 directory.

## **Test Data or Screenshots**

###### _By submitting this pull request, you are confirming the following:_

- I have reviewed the [Contribution Guidelines](https://github.com/web3swift-team/web3swift/blob/develop/CONTRIBUTION.md).
- I have performed a self-review of my own code.
- I have updated my repository to match the `develop` branch.
- I have included test data or screenshots that prove my fix is effective or that my feature works.
- I have checked that all tests work and swiftlint is not throwing any errors/warnings.
