### PR TITLE
Add `Sendable` conformance to various structs and enums

### DIFF
--- a/Sources/Web3Core/EthereumAddress/EthereumAddress.swift
+++ b/Sources/Web3Core/EthereumAddress/EthereumAddress.swift
@@ -9,8 +9,8 @@
 import Foundation
 import CryptoSwift
 
-public struct EthereumAddress: Equatable {
-    public enum AddressType {
+public struct EthereumAddress: Equatable, Sendable {
+    public enum AddressType: Sendable {
         case normal
         case contractDeployment
     }

--- a/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
+++ b/Sources/Web3Core/KeystoreManager/BIP32Keystore.swift
@@ -62,7 +62,7 @@ public class BIP32Keystore: AbstractKeystore {
 
     private static let KeystoreParamsBIP32Version = 4
 
-    public private (set) var addressStorage: PathAddressStorage
+    public private(set) var addressStorage: PathAddressStorage
 
     public convenience init?(_ jsonString: String) {
         let lowercaseJSON = jsonString.lowercased()

--- a/Sources/Web3Core/Structure/Block/BlockNumber.swift
+++ b/Sources/Web3Core/Structure/Block/BlockNumber.swift
@@ -8,7 +8,7 @@
 import Foundation
 import BigInt
 
-public enum BlockNumber: CustomStringConvertible {
+public enum BlockNumber: CustomStringConvertible, Sendable {
 
     case pending
     /// Latest block of a chain

--- a/Sources/Web3Core/Transaction/CodableTransaction.swift
+++ b/Sources/Web3Core/Transaction/CodableTransaction.swift
@@ -10,7 +10,7 @@ import BigInt
 /// Structure capable of carying the parameters for any transaction type.
 /// While most fields in this struct are optional, they are not necessarily
 /// optional for the type of transaction they apply to.
-public struct CodableTransaction {
+public struct CodableTransaction: Sendable {
     /// internal access only. The transaction envelope object itself that contains all the transaction data
     /// and type specific implementation
     internal var envelope: AbstractEnvelope

--- a/Sources/Web3Core/Transaction/Envelope/AbstractEnvelope.swift
+++ b/Sources/Web3Core/Transaction/Envelope/AbstractEnvelope.swift
@@ -21,7 +21,7 @@ import BigInt
 */
 
 /// Enumeration for supported transaction types
-public enum TransactionType: UInt, CustomStringConvertible, CaseIterable {
+public enum TransactionType: UInt, CustomStringConvertible, CaseIterable, Sendable {
 
     /// For untyped and type 0 transactions EIP155 and older
     case legacy
@@ -62,7 +62,7 @@ public enum EncodeType {
 /// All envelopes must conform to this protocol to work with `CodableTransaction`
 /// each implementation holds all the type specific data
 /// and implements the type specific encoding/decoding
-protocol AbstractEnvelope: CustomStringConvertible { // possibly add Codable?
+protocol AbstractEnvelope: CustomStringConvertible, Sendable { // possibly add Codable?
 
     /// The type of transaction this envelope represents
     var type: TransactionType { get }

--- a/Sources/Web3Core/Transaction/Envelope/EIP2930Envelope.swift
+++ b/Sources/Web3Core/Transaction/Envelope/EIP2930Envelope.swift
@@ -8,6 +8,7 @@ import Foundation
 import BigInt
 
 public struct EIP2930Envelope: EIP2718Envelope, EIP2930Compatible {
+
     public let type: TransactionType = .eip2930
 
     // common parameters for any transaction
@@ -221,7 +222,7 @@ extension EIP2930Envelope {
     }
 }
 
-public struct AccessListEntry: CustomStringConvertible, Codable {
+public struct AccessListEntry: CustomStringConvertible, Codable, Sendable {
     var address: EthereumAddress
     var storageKeys: [BigUInt]
 

--- a/Sources/Web3Core/Transaction/TransactionMetadata.swift
+++ b/Sources/Web3Core/Transaction/TransactionMetadata.swift
@@ -11,7 +11,7 @@ import BigInt
 /// returned by nodes when reading a transaction
 /// from the blockchain. The data here is not
 /// part of the transaction itself
-public struct TransactionMetadata {
+public struct TransactionMetadata: Sendable {
 
     /// hash for the block that contains this transaction on chain
     public var blockHash: Data?

--- a/Sources/web3swift/Tokens/ERC20/ERC20BasePropertiesProvider.swift
+++ b/Sources/web3swift/Tokens/ERC20/ERC20BasePropertiesProvider.swift
@@ -15,7 +15,7 @@ public final class ERC20BasePropertiesProvider {
     var decimals: UInt8?
 
     private let contract: Web3.Contract
-    private (set) var hasReadProperties: Bool = false
+    private(set) var hasReadProperties: Bool = false
     init(contract: Web3.Contract) {
         self.contract = contract
     }

--- a/Tests/web3swiftTests/localTests/EventloopTests.swift
+++ b/Tests/web3swiftTests/localTests/EventloopTests.swift
@@ -15,7 +15,7 @@ class EventloopTests: XCTestCase {
         let expectation = self.expectation(description: "Waiting")
         func getBlockNumber(_ web3: Web3) async {
             do {
-                let blockNumber = try await web3.eth.blockNumber()
+                _ = try await web3.eth.blockNumber()
                 ticksToWait = ticksToWait - 1
                 if ticksToWait == 0 {
                     expectation.fulfill()


### PR DESCRIPTION
- Updated `EthereumAddress` and its nested `AddressType` enum to conform to `Sendable`.
- Modified `BlockNumber` enum to conform to `Sendable`.
- Added `Sendable` conformance to `CodableTransaction` struct.
- Updated `TransactionType` enum and `AbstractEnvelope` protocol to conform to `Sendable`.
- Added `Sendable` conformance to `AccessListEntry` struct.
- Modified `TransactionMetadata` struct to conform to `Sendable`.


## **Test Data or Screenshots**


